### PR TITLE
Fixed crash when query only matches the name of a cafe

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/eatery/MainActivity.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/MainActivity.java
@@ -363,6 +363,7 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
             mCursorDrawableRes.setAccessible(true);
             mCursorDrawableRes.set(searchTextView, R.drawable.cursor); //This sets the cursor resource ID to 0 or @null which will make it visible on white background
         } catch (Exception e) {
+            // Don't do anything
         }
 
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {

--- a/app/src/main/java/com/cornellappdev/android/eatery/MainActivity.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/MainActivity.java
@@ -377,6 +377,7 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
                 }
                 // Query given
                 else {
+                    query = query.trim();
                     ArrayList<CafeteriaModel> filteredList = new ArrayList<>();
                     searchPressed = true;
                     // If none of the buttons clicked, loop through cafeList
@@ -433,6 +434,7 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
                 }
                 // Some text given
                 else {
+                    newText = newText.trim();
                     ArrayList<CafeteriaModel> filteredList = new ArrayList<>();
                     searchPressed = true;
                     // If no buttons clicked, loop through cafelist

--- a/app/src/main/java/com/cornellappdev/android/eatery/MainActivity.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/MainActivity.java
@@ -35,26 +35,27 @@ import java.util.HashSet;
 
 public class MainActivity extends AppCompatActivity implements MainListAdapter.ListAdapterOnClickHandler {
 
-    public RecyclerView mRecyclerView;
+    public static boolean searchPressed = false;
+
     public ArrayList<CafeteriaModel> cafeList = new ArrayList<>(); //holds all cafes
     public ArrayList<CafeteriaModel> currentList = new ArrayList<>(); //button filter list
     public ArrayList<CafeteriaModel> searchList = new ArrayList<>(); // searchbar filter list
-    public CafeteriaDbHelper dbHelper;
-    public MainListAdapter listAdapter;
-    public boolean northPressed = false;
-    public boolean centralPressed = false;
-    public boolean westPressed = false;
-    public boolean swipesPressed = false;
-    public boolean brbPressed = false;
-    public static boolean searchPressed = false;
+    public BottomNavigationView bnv;
     public Button northButton;
     public Button westButton;
     public Button centralButton;
     public Button swipesButton;
     public Button brbButton;
+    public CafeteriaDbHelper dbHelper;
+    public MainListAdapter listAdapter;
     public ProgressBar progressBar;
-    public BottomNavigationView bnv;
+    public RecyclerView mRecyclerView;
     public RelativeLayout splash;
+    public boolean northPressed = false;
+    public boolean centralPressed = false;
+    public boolean westPressed = false;
+    public boolean swipesPressed = false;
+    public boolean brbPressed = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -80,16 +81,20 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
             if (JsonUtilities.parseJson(dbHelper.getLastRow(), getApplicationContext()) != null) {
                 cafeList = JsonUtilities.parseJson(dbHelper.getLastRow(), getApplicationContext());
             }
+            Collections.sort(cafeList);
             currentList = cafeList;
             searchList = cafeList;
-            Collections.sort(currentList);
-            Collections.sort(searchList);
 
             mRecyclerView.setHasFixedSize(true);
-            LinearLayoutManager layoutManager = new LinearLayoutManager(getApplicationContext(), LinearLayout.VERTICAL, false);
+            LinearLayoutManager layoutManager =
+                    new LinearLayoutManager(getApplicationContext(), LinearLayout.VERTICAL, false);
             mRecyclerView.setLayoutManager(layoutManager);
-            Collections.sort(cafeList);
-            listAdapter = new MainListAdapter(getApplicationContext(), MainActivity.this, cafeList.size(), cafeList);
+
+            listAdapter =
+                    new MainListAdapter(getApplicationContext(),
+                            MainActivity.this,
+                            cafeList.size(),
+                            cafeList);
             mRecyclerView.setAdapter(listAdapter);
         } else {
             new ProcessJson().execute("");
@@ -109,7 +114,10 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
                         startActivity(intent);
                         break;
                     case R.id.action_brb:
-                        Toast toast = Toast.makeText(getApplicationContext(), "Coming Soon", Toast.LENGTH_SHORT);
+                        Toast toast =
+                                Toast.makeText(getApplicationContext(),
+                                        "Coming Soon",
+                                        Toast.LENGTH_SHORT);
                         toast.show();
                         break;
                 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/MainActivity.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/MainActivity.java
@@ -33,12 +33,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 
-public class MainActivity extends AppCompatActivity implements MainListAdapter.ListAdapterOnClickHandler{
+public class MainActivity extends AppCompatActivity implements MainListAdapter.ListAdapterOnClickHandler {
 
     public RecyclerView mRecyclerView;
-    public ArrayList<CafeteriaModel> cafeList =new ArrayList<>(); //holds all cafes
-    public ArrayList<CafeteriaModel> currentList= new ArrayList<>(); //button filter list
-    public ArrayList<CafeteriaModel> searchList= new ArrayList<>(); // searchbar filter list
+    public ArrayList<CafeteriaModel> cafeList = new ArrayList<>(); //holds all cafes
+    public ArrayList<CafeteriaModel> currentList = new ArrayList<>(); //button filter list
+    public ArrayList<CafeteriaModel> searchList = new ArrayList<>(); // searchbar filter list
     public CafeteriaDbHelper dbHelper;
     public MainListAdapter listAdapter;
     public boolean northPressed = false;
@@ -75,10 +75,10 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
         getSupportActionBar().hide();
 
         ConnectionUtilities con = new ConnectionUtilities(this);
-        if(!con.isNetworkAvailable()){
+        if (!con.isNetworkAvailable()) {
             cafeList = new ArrayList<>();
-            if(JsonUtilities.parseJson(dbHelper.getLastRow(),getApplicationContext())!=null){
-                cafeList = JsonUtilities.parseJson(dbHelper.getLastRow(),getApplicationContext());
+            if (JsonUtilities.parseJson(dbHelper.getLastRow(), getApplicationContext()) != null) {
+                cafeList = JsonUtilities.parseJson(dbHelper.getLastRow(), getApplicationContext());
             }
             currentList = cafeList;
             searchList = cafeList;
@@ -86,13 +86,12 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
             Collections.sort(searchList);
 
             mRecyclerView.setHasFixedSize(true);
-            LinearLayoutManager layoutManager = new LinearLayoutManager(getApplicationContext(), LinearLayout.VERTICAL,false);
+            LinearLayoutManager layoutManager = new LinearLayoutManager(getApplicationContext(), LinearLayout.VERTICAL, false);
             mRecyclerView.setLayoutManager(layoutManager);
             Collections.sort(cafeList);
-            listAdapter = new MainListAdapter(getApplicationContext(), MainActivity.this,cafeList.size(), cafeList);
+            listAdapter = new MainListAdapter(getApplicationContext(), MainActivity.this, cafeList.size(), cafeList);
             mRecyclerView.setAdapter(listAdapter);
-        }
-        else {
+        } else {
             new ProcessJson().execute("");
         }
 
@@ -101,7 +100,7 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
             @Override
             public boolean onNavigationItemSelected(@NonNull MenuItem item) {
                 Intent intent;
-                switch(item.getItemId()) {
+                switch (item.getItemId()) {
                     case R.id.action_home:
                         break;
                     case R.id.action_week:
@@ -120,33 +119,33 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
     }
 
     // Change button and background color
-    public void changeButtonColor(String textColor, String backgroundColor, Button button){
+    public void changeButtonColor(String textColor, String backgroundColor, Button button) {
         button.setTextColor(Color.parseColor(textColor));
         GradientDrawable bgShape = (GradientDrawable) button.getBackground();
         bgShape.setColor(Color.parseColor(backgroundColor));
     }
 
     // TODO(lesley): reduce redundancy in this method, please
-    public void filterClick(View view){
+    public void filterClick(View view) {
         int id = view.getId();
 
-        switch(id){
+        switch (id) {
             case R.id.northButton:
-                if(!northPressed) {
+                if (!northPressed) {
                     // Change color of north button + set boolean(clicked)
-                    changeButtonColor("#FFFFFF","#4B7FBE",northButton);
+                    changeButtonColor("#FFFFFF", "#4B7FBE", northButton);
                     northPressed = true;
 
                     // Change color of west+ central + set booleans(unclicked)
                     centralPressed = false;
                     westPressed = false;
-                    changeButtonColor("#4B7FBE","#F2F2F2",westButton);
-                    changeButtonColor("#4B7FBE","#F2F2F2",centralButton);
+                    changeButtonColor("#4B7FBE", "#F2F2F2", westButton);
+                    changeButtonColor("#4B7FBE", "#F2F2F2", centralButton);
 
                     // Go through searchList(search view list)
                     ArrayList<CafeteriaModel> northList = new ArrayList<>();
-                    for(CafeteriaModel model : searchList){
-                        if(model.getArea()== CafeteriaModel.CafeteriaArea.NORTH){
+                    for (CafeteriaModel model : searchList) {
+                        if (model.getArea() == CafeteriaModel.CafeteriaArea.NORTH) {
                             northList.add(model);
                         }
                     }
@@ -155,27 +154,27 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
                     break;
                 }
                 // North button is not pressed or unclicked
-                else{
-                    changeButtonColor("#4B7FBE","#F2F2F2",northButton);
+                else {
+                    changeButtonColor("#4B7FBE", "#F2F2F2", northButton);
                     northPressed = false;
                     currentList = searchList;
                     break;
                 }
             case R.id.centralButton:
-                if(!centralPressed){
+                if (!centralPressed) {
                     // Change color of central button + set boolean(clicked)
-                    changeButtonColor("#FFFFFF","#4B7FBE",centralButton);
+                    changeButtonColor("#FFFFFF", "#4B7FBE", centralButton);
                     centralPressed = true;
 
                     // Change color of north+ west + set booleans(unclicked)
                     northPressed = false;
                     westPressed = false;
-                    changeButtonColor("#4B7FBE","#F2F2F2",westButton);
-                    changeButtonColor("#4B7FBE","#F2F2F2",northButton);
+                    changeButtonColor("#4B7FBE", "#F2F2F2", westButton);
+                    changeButtonColor("#4B7FBE", "#F2F2F2", northButton);
 
                     ArrayList<CafeteriaModel> centralList = new ArrayList<>();
-                    for(CafeteriaModel model : searchList){
-                        if(model.getArea()== CafeteriaModel.CafeteriaArea.CENTRAL){
+                    for (CafeteriaModel model : searchList) {
+                        if (model.getArea() == CafeteriaModel.CafeteriaArea.CENTRAL) {
                             centralList.add(model);
                         }
                     }
@@ -183,27 +182,27 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
                     break;
                 }
                 // Central button is (not pressed) or unclicked
-                else{
-                    changeButtonColor("#4B7FBE","#F2F2F2",centralButton);
+                else {
+                    changeButtonColor("#4B7FBE", "#F2F2F2", centralButton);
                     centralPressed = false;
                     currentList = searchList;
                     break;
                 }
             case R.id.westButton:
-                if(!westPressed){
+                if (!westPressed) {
                     // Change color of west button + set boolean(clicked)
-                    changeButtonColor("#FFFFFF","#4B7FBE",westButton);
+                    changeButtonColor("#FFFFFF", "#4B7FBE", westButton);
                     westPressed = true;
 
                     // Change color of north and central button + set booleans(unclicked)
                     centralPressed = false;
                     northPressed = false;
-                    changeButtonColor("#4B7FBE","#F2F2F2",northButton);
-                    changeButtonColor("#4B7FBE","#F2F2F2",centralButton);
+                    changeButtonColor("#4B7FBE", "#F2F2F2", northButton);
+                    changeButtonColor("#4B7FBE", "#F2F2F2", centralButton);
 
                     ArrayList<CafeteriaModel> westList = new ArrayList<>();
-                    for(CafeteriaModel model : searchList){
-                        if(model.getArea()== CafeteriaModel.CafeteriaArea.WEST){
+                    for (CafeteriaModel model : searchList) {
+                        if (model.getArea() == CafeteriaModel.CafeteriaArea.WEST) {
                             westList.add(model);
                         }
                     }
@@ -211,51 +210,51 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
                     break;
                 }
                 // West button is not pressed or unclicked
-                else{
-                    changeButtonColor("#4B7FBE","#F2F2F2",westButton);
+                else {
+                    changeButtonColor("#4B7FBE", "#F2F2F2", westButton);
                     westPressed = false;
                     currentList = searchList;
                     break;
                 }
             case R.id.swipes:
                 // Swipe button is pressed
-                if(!swipesPressed){
+                if (!swipesPressed) {
                     // Set Swipe button color + boolean(clicked)
-                    changeButtonColor("#FFFFFF","#4B7FBE",swipesButton);
+                    changeButtonColor("#FFFFFF", "#4B7FBE", swipesButton);
                     swipesPressed = true;
                     // Set brb button color + boolean(unclicked)
                     brbPressed = false;
-                    changeButtonColor("#4B7FBE","#F2F2F2",brbButton);
+                    changeButtonColor("#4B7FBE", "#F2F2F2", brbButton);
 
                     // If north is also pressed, north + swipe
                     ArrayList<CafeteriaModel> swipeList = new ArrayList<>();
-                    if(northPressed){
-                        for(CafeteriaModel model: searchList){
-                            if(model.getArea()==CafeteriaModel.CafeteriaArea.NORTH && model.getPay_methods().contains("Meal Plan - Swipe")){
+                    if (northPressed) {
+                        for (CafeteriaModel model : searchList) {
+                            if (model.getArea() == CafeteriaModel.CafeteriaArea.NORTH && model.getPay_methods().contains("Meal Plan - Swipe")) {
                                 swipeList.add(model);
                             }
                         }
                     }
                     // If west is also pressed , west+swipe
-                    else if(westPressed){
-                        for(CafeteriaModel model: searchList){
-                            if(model.getArea()==CafeteriaModel.CafeteriaArea.WEST && model.getPay_methods().contains("Meal Plan - Swipe")){
+                    else if (westPressed) {
+                        for (CafeteriaModel model : searchList) {
+                            if (model.getArea() == CafeteriaModel.CafeteriaArea.WEST && model.getPay_methods().contains("Meal Plan - Swipe")) {
                                 swipeList.add(model);
                             }
                         }
                     }
                     // If central is also pressed, central + swipe
-                    else if(centralPressed){
-                        for(CafeteriaModel model: searchList){
-                            if(model.getArea()==CafeteriaModel.CafeteriaArea.CENTRAL && model.getPay_methods().contains("Meal Plan - Swipe")){
+                    else if (centralPressed) {
+                        for (CafeteriaModel model : searchList) {
+                            if (model.getArea() == CafeteriaModel.CafeteriaArea.CENTRAL && model.getPay_methods().contains("Meal Plan - Swipe")) {
                                 swipeList.add(model);
                             }
                         }
                     }
                     // If no area button pressed, swipe
-                    else{
-                        for(CafeteriaModel model: searchList){
-                            if(model.getPay_methods().contains("Meal Plan - Swipe")){
+                    else {
+                        for (CafeteriaModel model : searchList) {
+                            if (model.getPay_methods().contains("Meal Plan - Swipe")) {
                                 swipeList.add(model);
                             }
                         }
@@ -264,8 +263,8 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
                     break;
                 }
                 // Swipe not pressed or unclicked
-                else{
-                    changeButtonColor("#4B7FBE","#F2F2F2",swipesButton);
+                else {
+                    changeButtonColor("#4B7FBE", "#F2F2F2", swipesButton);
                     swipesPressed = false;
                     currentList = searchList;
                     break;
@@ -273,67 +272,66 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
                 }
             case R.id.brb:
                 // Brb pressed
-                if(!brbPressed){
+                if (!brbPressed) {
                     // Set brb button color + boolean(clicked)
-                    changeButtonColor("#FFFFFF","#4B7FBE",brbButton);
+                    changeButtonColor("#FFFFFF", "#4B7FBE", brbButton);
                     brbPressed = true;
 
                     // Set swipe button color + boolean(unclicked)
                     swipesPressed = false;
-                    changeButtonColor("#4B7FBE","#F2F2F2",swipesButton);
+                    changeButtonColor("#4B7FBE", "#F2F2F2", swipesButton);
 
                     ArrayList<CafeteriaModel> brbList = new ArrayList<>();
 
                     // North + brb
-                    if(northPressed){
-                        for(CafeteriaModel model: searchList){
-                            if(model.getArea()==CafeteriaModel.CafeteriaArea.NORTH && model.getPay_methods().contains("Cornell Card")){
+                    if (northPressed) {
+                        for (CafeteriaModel model : searchList) {
+                            if (model.getArea() == CafeteriaModel.CafeteriaArea.NORTH && model.getPay_methods().contains("Cornell Card")) {
                                 brbList.add(model);
                             }
                         }
                     }
                     // West + brb
-                    else if(westPressed){
-                        for(CafeteriaModel model: searchList){
-                            if(model.getArea()==CafeteriaModel.CafeteriaArea.WEST && model.getPay_methods().contains("Cornell Card")){
+                    else if (westPressed) {
+                        for (CafeteriaModel model : searchList) {
+                            if (model.getArea() == CafeteriaModel.CafeteriaArea.WEST && model.getPay_methods().contains("Cornell Card")) {
                                 brbList.add(model);
                             }
                         }
                     }
                     // Central + brb
-                    else if(centralPressed){
-                        for(CafeteriaModel model: searchList){
-                            if(model.getArea()==CafeteriaModel.CafeteriaArea.CENTRAL && model.getPay_methods().contains("Cornell Card")){
+                    else if (centralPressed) {
+                        for (CafeteriaModel model : searchList) {
+                            if (model.getArea() == CafeteriaModel.CafeteriaArea.CENTRAL && model.getPay_methods().contains("Cornell Card")) {
                                 brbList.add(model);
                             }
                         }
                     }
                     // Brb
-                    else{
-                        for(CafeteriaModel model: searchList){
-                            if(model.getPay_methods().contains("Cornell Card")){
+                    else {
+                        for (CafeteriaModel model : searchList) {
+                            if (model.getPay_methods().contains("Cornell Card")) {
                                 brbList.add(model);
                             }
                         }
                     }
                     currentList = brbList;
                     break;
-                }
-                else{
+                } else {
                     // Brb unclicked
-                    changeButtonColor("#4B7FBE","#F2F2F2",brbButton);
+                    changeButtonColor("#4B7FBE", "#F2F2F2", brbButton);
                     brbPressed = false;
                     currentList = searchList;
                     break;
                 }
         }
         Collections.sort(currentList);
-        listAdapter.setList(currentList,currentList.size(), null);
+        listAdapter.setList(currentList, currentList.size(), null);
     }
 
     @Override
-    public void onClick(int position,ArrayList<CafeteriaModel> list) {
-        Intent intent = new Intent(this,MenuActivity.class);
+    public void onClick(int position, ArrayList<CafeteriaModel> list) {
+        Intent intent = new Intent(this, MenuActivity.class);
         intent.putExtra("testData", list);
         intent.putExtra("cafeInfo", list.get(position));
         intent.putExtra("locName", list.get(position).getNickName());
@@ -356,7 +354,7 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        getMenuInflater().inflate(R.menu.menu_main,menu);
+        getMenuInflater().inflate(R.menu.menu_main, menu);
         MenuItem searchItem = menu.findItem(R.id.action_search);
         SearchView searchView = (SearchView) searchItem.getActionView();
         AutoCompleteTextView searchTextView = searchView.findViewById(android.support.v7.appcompat.R.id.search_src_text);
@@ -371,7 +369,7 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
             @Override
             public boolean onQueryTextSubmit(String query) {
                 // No query given, set searchList to cafeList
-                if(query.length()==0){
+                if (query.length() == 0) {
                     searchList = cafeList;
                     searchPressed = false;
                 }
@@ -381,18 +379,18 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
                     ArrayList<CafeteriaModel> filteredList = new ArrayList<>();
                     searchPressed = true;
                     // If none of the buttons clicked, loop through cafeList
-                    if(!northPressed&&!centralPressed&&!westPressed&&!swipesPressed&&!brbPressed){
+                    if (!northPressed && !centralPressed && !westPressed && !swipesPressed && !brbPressed) {
                         for (CafeteriaModel model : cafeList) {
                             HashSet<String> mealSet = model.getMealItems();
 
                             //check the nickname of the cafe and if it's not already in the filtered list add it to the list
-                            if(model.getNickName().toLowerCase().contains((query.toLowerCase())) && !filteredList.contains(model)){
+                            if (model.getNickName().toLowerCase().contains((query.toLowerCase())) && !filteredList.contains(model)) {
                                 filteredList.add(model);
                             }
 
-                            for(String item : mealSet){
-                                if(item.toLowerCase().contains(query.toLowerCase())){
-                                    if(!filteredList.contains(model))
+                            for (String item : mealSet) {
+                                if (item.toLowerCase().contains(query.toLowerCase())) {
+                                    if (!filteredList.contains(model))
                                         filteredList.add(model);
                                 }
                             }
@@ -406,13 +404,13 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
                             HashSet<String> mealSet = model.getMealItems();
 
                             //check the nickname of the cafe and if it's not already in the filtered list add it to the list
-                            if(model.getNickName().toLowerCase().contains((query.toLowerCase())) && !filteredList.contains(model)){
+                            if (model.getNickName().toLowerCase().contains((query.toLowerCase())) && !filteredList.contains(model)) {
                                 filteredList.add(model);
                             }
 
-                            for(String item : mealSet){
-                                if(item.toLowerCase().contains(query.toLowerCase())){
-                                    if(!filteredList.contains(model))
+                            for (String item : mealSet) {
+                                if (item.toLowerCase().contains(query.toLowerCase())) {
+                                    if (!filteredList.contains(model))
                                         filteredList.add(model);
                                 }
                             }
@@ -428,7 +426,7 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
             @Override
             public boolean onQueryTextChange(String newText) {
                 // No text given
-                if (newText.length()==0) {
+                if (newText.length() == 0) {
                     searchList = cafeList;
                     searchPressed = false;
                 }
@@ -438,30 +436,30 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
                     ArrayList<CafeteriaModel> filteredList = new ArrayList<>();
                     searchPressed = true;
                     // If no buttons clicked, loop through cafelist
-                    if(!northPressed&&!centralPressed&&!westPressed&&!swipesPressed&&!brbPressed){
+                    if (!northPressed && !centralPressed && !westPressed && !swipesPressed && !brbPressed) {
                         for (CafeteriaModel model : cafeList) {
 
                             HashSet<String> mealSet = model.getMealItems();
-                            ArrayList<String> matchedItems= new ArrayList<String>();
+                            ArrayList<String> matchedItems = new ArrayList<>();
                             ArrayList<String> full_items = new ArrayList<>();
 
                             boolean found_item = false;
-                            for(String item : mealSet){
-                                if(item.toLowerCase().contains(newText.toLowerCase())){
+                            for (String item : mealSet) {
+                                if (item.toLowerCase().contains(newText.toLowerCase())) {
                                     matchedItems.add(item);
                                     found_item = true;
                                 }
                                 full_items.add(item);
 
                             }
-                            if(found_item){
+                            if (found_item) {
                                 model.setSearchedItems(matchedItems);
-                                if(!filteredList.contains(model))
+                                if (!filteredList.contains(model))
                                     filteredList.add(model);
                             }
 
                             //check the nickname of the cafe and if it's not already in the filtered list add it to the list
-                            if(model.getNickName().toLowerCase().contains((newText.toLowerCase()))&&!filteredList.contains(model)&&model.isOpen().equals("Open")){
+                            if (model.getNickName().toLowerCase().contains((newText.toLowerCase())) && !filteredList.contains(model) && model.isOpen().equals("Open")) {
                                 model.setSearchedItems(full_items);
                                 filteredList.add(model);
                             }
@@ -472,17 +470,17 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
                     else {
                         for (CafeteriaModel model : currentList) {
                             HashSet<String> mealSet = model.getMealItems();
-                            ArrayList<String> matchedItems= new ArrayList<String>();
+                            ArrayList<String> matchedItems = new ArrayList<>();
                             boolean found_item = false;
-                            for(String item : mealSet){
-                                if(item.toLowerCase().contains(newText.toLowerCase())){
+                            for (String item : mealSet) {
+                                if (item.toLowerCase().contains(newText.toLowerCase())) {
                                     matchedItems.add(item);
                                     found_item = true;
                                 }
                             }
-                            if(found_item){
+                            if (found_item) {
                                 model.setSearchedItems(matchedItems);
-                                if(!filteredList.contains(model))
+                                if (!filteredList.contains(model))
                                     filteredList.add(model);
                             }
                         }
@@ -497,11 +495,11 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
         return super.onCreateOptionsMenu(menu);
     }
 
-    public class ProcessJson extends AsyncTask<String, Void, ArrayList<CafeteriaModel>>{
+    public class ProcessJson extends AsyncTask<String, Void, ArrayList<CafeteriaModel>> {
         @Override
         protected ArrayList<CafeteriaModel> doInBackground(String... params) {
             String json = NetworkUtilities.getJson();
-           dbHelper.addData(json);
+            dbHelper.addData(json);
 
             cafeList = JsonUtilities.parseJson(json, getApplicationContext());
             currentList = cafeList;
@@ -519,10 +517,10 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
             getSupportActionBar().show();
 
             mRecyclerView.setHasFixedSize(true);
-            LinearLayoutManager layoutManager = new LinearLayoutManager(getApplicationContext(), LinearLayout.VERTICAL,false);
+            LinearLayoutManager layoutManager = new LinearLayoutManager(getApplicationContext(), LinearLayout.VERTICAL, false);
             mRecyclerView.setLayoutManager(layoutManager);
 
-            listAdapter = new MainListAdapter(getApplicationContext(), MainActivity.this,result.size(), cafeList);
+            listAdapter = new MainListAdapter(getApplicationContext(), MainActivity.this, result.size(), cafeList);
             mRecyclerView.setAdapter(listAdapter);
             mRecyclerView.setVisibility(View.VISIBLE);
             progressBar.setVisibility(View.GONE);

--- a/app/src/main/java/com/cornellappdev/android/eatery/MainActivity.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/MainActivity.java
@@ -421,7 +421,7 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
                     }
                 }
                 Collections.sort(searchList);
-                listAdapter.setList(searchList, searchList.size(), query);
+                listAdapter.setList(searchList, searchList.size(), query.length() == 0 ? null : query);
                 return false;
             }
 
@@ -490,7 +490,7 @@ public class MainActivity extends AppCompatActivity implements MainListAdapter.L
                     }
                 }
                 Collections.sort(searchList);
-                listAdapter.setList(searchList, searchList.size(), newText);
+                listAdapter.setList(searchList, searchList.size(), newText.length() == 0 ? null : newText);
                 return false;
             }
         });

--- a/app/src/main/java/com/cornellappdev/android/eatery/MainListAdapter.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/MainListAdapter.java
@@ -137,12 +137,14 @@ public class MainListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                 if (mQuery != null) {
                     // Find case-matching instances to bold
                     items = items.replaceAll(mQuery, "<b>" + mQuery + "</b>");
-                    // Find instances that don't make the case of the query and bold them
+                    // Find instances that don't match the case of the query and bold them
                     int begIndex = items.toLowerCase().indexOf(mQuery.toLowerCase());
-                    String queryMatchingItemCase =
-                            items.substring(begIndex, begIndex + mQuery.length());
-                    items = items.replaceAll(queryMatchingItemCase,
-                            "<b>" + queryMatchingItemCase + "</b>");
+                    if (begIndex >= 0) {
+                        String queryMatchingItemCase =
+                                items.substring(begIndex, begIndex + mQuery.length());
+                        items = items.replaceAll(queryMatchingItemCase,
+                                "<b>" + queryMatchingItemCase + "</b>");
+                    }
                 }
 
                 holder2.cafe_items.setText(Html.fromHtml(items.replace(", ", "<br/>")));

--- a/app/src/main/java/com/cornellappdev/android/eatery/MainListAdapter.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/MainListAdapter.java
@@ -27,29 +27,23 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-/**
- * Created by JC on 2/22/18.
- */
-
-public class MainListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>{
-    Context mContext;
-    final private ListAdapterOnClickHandler mListAdapterOnClickHandler;
+public class MainListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+    private final Context mContext;
+    private final ListAdapterOnClickHandler mListAdapterOnClickHandler;
     private int mCount;
     private String mQuery;
-    private ArrayList<CafeteriaModel> cafeList;
     private ArrayList<CafeteriaModel> cafeListFiltered;
     private final int TEXT = 1;
     private final int IMAGE = 0;
 
     public interface ListAdapterOnClickHandler {
-        void onClick(int position,ArrayList<CafeteriaModel> list);
+        void onClick(int position, ArrayList<CafeteriaModel> list);
     }
 
-    public MainListAdapter(Context context, ListAdapterOnClickHandler clickHandler, int count, ArrayList<CafeteriaModel> list) {
+    MainListAdapter(Context context, ListAdapterOnClickHandler clickHandler, int count, ArrayList<CafeteriaModel> list) {
         mContext = context;
         mListAdapterOnClickHandler = clickHandler;
         mCount = count;
-        cafeList = list;
         cafeListFiltered = list;
 
         // Logcat for Fresco
@@ -62,29 +56,31 @@ public class MainListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         FLog.setMinimumLoggingLevel(FLog.VERBOSE);
     }
 
-    public void setList(ArrayList<CafeteriaModel> list, int count, String query){
+    void setList(ArrayList<CafeteriaModel> list, int count, String query) {
         mQuery = query;
         mCount = count;
         cafeListFiltered = list;
         notifyDataSetChanged();
     }
 
-    /**Set view to layout of CardView**/
+    /**
+     * Set view to layout of CardView
+     **/
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-        View view = null;
+        final View view;
+        final int layoutId;
         RecyclerView.ViewHolder viewHolder = null;
-        int layoutId = 0;
-        switch(viewType){
+        switch (viewType) {
             case IMAGE:
                 layoutId = R.layout.card_item;
-                view = LayoutInflater.from(mContext).inflate(layoutId, parent,false);
+                view = LayoutInflater.from(mContext).inflate(layoutId, parent, false);
                 view.setFocusable(true);
                 viewHolder = new ListAdapterViewHolder(view);
                 break;
             case TEXT:
                 layoutId = R.layout.card_text;
-                view = LayoutInflater.from(mContext).inflate(layoutId,parent,false);
+                view = LayoutInflater.from(mContext).inflate(layoutId, parent, false);
                 viewHolder = new TextAdapterViewHolder(view);
                 break;
         }
@@ -93,9 +89,9 @@ public class MainListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
     @Override
     public void onBindViewHolder(RecyclerView.ViewHolder input_holder, int position) {
-        switch (input_holder.getItemViewType()){
+        switch (input_holder.getItemViewType()) {
             case IMAGE:
-                ListAdapterViewHolder holder = (ListAdapterViewHolder)input_holder;
+                ListAdapterViewHolder holder = (ListAdapterViewHolder) input_holder;
 
                 holder.cafeName.setText(cafeListFiltered.get(position).getNickName());
 
@@ -111,13 +107,13 @@ public class MainListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                         Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 
                 Collections.sort(cafeListFiltered);
-                if(cafeListFiltered.get(position).getCurrentStatus()==CafeteriaModel.Status.CLOSED){
+                if (cafeListFiltered.get(position).getCurrentStatus() == CafeteriaModel.Status.CLOSED) {
                     holder.line.setBackgroundColor(Color.parseColor("#FF0000"));
                     holder.cafeOpen.setText("Closed");
-                } else if(cafeListFiltered.get(position).getCurrentStatus()==CafeteriaModel.Status.CLOSINGSOON){
+                } else if (cafeListFiltered.get(position).getCurrentStatus() == CafeteriaModel.Status.CLOSINGSOON) {
                     holder.line.setBackgroundColor(Color.parseColor("#E8F11F"));
                     holder.cafeOpen.setText("Closing Soon");
-                } else{
+                } else {
                     holder.line.setBackgroundColor(Color.parseColor("#00A350"));
                     holder.cafeOpen.setText("Open");
                 }
@@ -132,7 +128,7 @@ public class MainListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
                 ArrayList<String> itemList = cafeListFiltered.get(position).getSearchedItems();
                 Collections.sort(itemList);
-                String items = itemList.toString().substring(1, itemList.toString().length()-1);
+                String items = itemList.toString().substring(1, itemList.toString().length() - 1);
 
                 if (mQuery != null) {
                     // Fixes conflict with replacing character 'b' after inserting HTML bold tags
@@ -157,10 +153,10 @@ public class MainListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
     }
 
     @Override
-    public int getItemViewType(int position){
-        if(!MainActivity.searchPressed){
+    public int getItemViewType(int position) {
+        if (!MainActivity.searchPressed) {
             return IMAGE;
-        } else{
+        } else {
             return TEXT;
         }
     }
@@ -170,17 +166,17 @@ public class MainListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         return mCount;
     }
 
-    class ListAdapterViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener{
+    class ListAdapterViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
         TextView cafeName;
         TextView cafeTime;
         TextView cafeOpen;
         View line;
         SimpleDraweeView cafeDrawee;
 
-        public ListAdapterViewHolder(View itemView) {
+        ListAdapterViewHolder(View itemView) {
             super(itemView);
-            cafeName =  itemView.findViewById(R.id.cafe_name);
-            cafeTime =  itemView.findViewById(R.id.cafe_time);
+            cafeName = itemView.findViewById(R.id.cafe_name);
+            cafeTime = itemView.findViewById(R.id.cafe_time);
             cafeOpen = itemView.findViewById(R.id.cafe_open);
             cafeDrawee = itemView.findViewById(R.id.cafe_image);
             line = itemView.findViewById(R.id.cardviewStatus);
@@ -191,19 +187,19 @@ public class MainListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         @Override
         public void onClick(View v) {
             int adapterPosition = getAdapterPosition();
-            mListAdapterOnClickHandler.onClick(adapterPosition,cafeListFiltered);
+            mListAdapterOnClickHandler.onClick(adapterPosition, cafeListFiltered);
 
         }
     }
 
-    class TextAdapterViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener{
+    class TextAdapterViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
         TextView cafe_name;
         TextView cafe_time;
         TextView cafe_time_info;
         TextView cafe_items;
 
 
-        public TextAdapterViewHolder(View itemView) {
+        TextAdapterViewHolder(View itemView) {
             super(itemView);
             cafe_name = itemView.findViewById(R.id.searchview_name);
             cafe_time = itemView.findViewById(R.id.searchview_open);
@@ -214,14 +210,14 @@ public class MainListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         }
 
         @Override
-        public void onClick(View v){
+        public void onClick(View v) {
             int adapterPosition = getAdapterPosition();
-            mListAdapterOnClickHandler.onClick(adapterPosition,cafeListFiltered);
+            mListAdapterOnClickHandler.onClick(adapterPosition, cafeListFiltered);
         }
 
     }
 
-    public static String convertName(String str) {
+    private static String convertName(String str) {
         if (str.equals("104West!.jpg")) return "104-West.jpg";
         if (str.equals("McCormick's.jpg")) return "mccormicks.jpg";
         if (str.equals("Franny's.jpg")) return "frannys.jpg";

--- a/app/src/main/java/com/cornellappdev/android/eatery/MainListAdapter.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/MainListAdapter.java
@@ -135,10 +135,14 @@ public class MainListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                 String items = itemList.toString().substring(1, itemList.toString().length()-1);
 
                 if (mQuery != null) {
+                    // Fixes conflict with replacing character 'b' after inserting HTML bold tags
+                    if (mQuery.equals("B")) mQuery = "b";
+
                     // Find case-matching instances to bold
                     items = items.replaceAll(mQuery, "<b>" + mQuery + "</b>");
+
                     // Find instances that don't match the case of the query and bold them
-                    int begIndex = items.toLowerCase().indexOf(mQuery.toLowerCase());
+                    int begIndex = items.replaceAll(mQuery, " ").toLowerCase().indexOf(mQuery.toLowerCase());
                     if (begIndex >= 0) {
                         String queryMatchingItemCase =
                                 items.substring(begIndex, begIndex + mQuery.length());


### PR DESCRIPTION
Previously, when you search for a Cafe like "Gimme Coffee", the app would crash because we previously assumed that every query is a substring of at least one menu item. This is no longer the case. Now, we only search for the query in the items list to bold it IF it is a substring of the item list in the first place. Otherwise, we can assume that the only reason we are presenting this cafe's card is if our query matched the name of the cafe itself.

Also, I found an edge case where if you search the letter "B" then our logic fails. We first replace all instances of the letter "B" with "<b>B</b>" and then replace all instances of the letter "b" with "<b>b</b>". The problem is that we added lowercase b's to the string in the previous step. Pretty interesting edge case.