### PR TITLE
Jonvi/ weekly menu, main list updates

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/eatery/ExpandableListAdapter.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ExpandableListAdapter.java
@@ -111,7 +111,6 @@ public class ExpandableListAdapter extends BaseExpandableListAdapter {
         headerText.setText(m);
         headerText.setTypeface(null, Typeface.NORMAL);
 
-
         TextView timetext1 = view.findViewById(R.id.time1);
 
         try {
@@ -158,9 +157,7 @@ public class ExpandableListAdapter extends BaseExpandableListAdapter {
                     ) {
                 timetext1.setText("Open from " + startTime + " to " + endTime);
                 timetext1.setTextColor(Color.parseColor("#1a84db"));
-            }
-
-            else{
+            } else{
                 String mealString = "";
                 if(mealIndex == 0) {
                     mealString = "Breakfast";
@@ -173,8 +170,9 @@ public class ExpandableListAdapter extends BaseExpandableListAdapter {
                 }
                 timetext1.setText("Closed for " + mealString);
                 timetext1.setTextColor(Color.parseColor("#989898"));
-
             }
+
+
 
 
         } catch (Exception e) {

--- a/app/src/main/java/com/cornellappdev/android/eatery/ExpandableListAdapter.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/ExpandableListAdapter.java
@@ -161,7 +161,19 @@ public class ExpandableListAdapter extends BaseExpandableListAdapter {
             }
 
             else{
-                timetext1.setText("Closed for " + meal.getType());
+                String mealString = "";
+                if(mealIndex == 0) {
+                    mealString = "Breakfast";
+                }else if(meal.getType().equals("Brunch")) {
+                    mealString = "Brunch";
+                }  else if(mealIndex == 1){
+                    mealString = "Lunch";
+                } else {
+                    mealString = "Dinner";
+                }
+                timetext1.setText("Closed for " + mealString);
+                timetext1.setTextColor(Color.parseColor("#989898"));
+
             }
 
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/MainListAdapter.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/MainListAdapter.java
@@ -119,10 +119,9 @@ public class MainListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
                 } else if(cafeListFiltered.get(position).getCurrentStatus()==CafeteriaModel.Status.CLOSINGSOON){
                     holder.cafeOpen.setText("Closing Soon");
-                    holder.cafeOpen.setTextColor(ContextCompat.getColor(mContext, R.color.green));
+                    holder.cafeOpen.setTextColor(ContextCompat.getColor(mContext, R.color.red));
                     holder.rlayout.setAlpha(1f);
-
-
+                    
                 } else{
                     holder.cafeOpen.setText("Open");
                     holder.cafeOpen.setTextColor(ContextCompat.getColor(mContext, R.color.green));

--- a/app/src/main/java/com/cornellappdev/android/eatery/MenuActivity.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/MenuActivity.java
@@ -14,6 +14,7 @@ import android.support.design.widget.TabLayout;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
@@ -99,11 +100,16 @@ public class MenuActivity extends AppCompatActivity {
 
         // Format string for opening/closing time
         cafeIsOpen = findViewById(R.id.ind_open);
-        cafeIsOpen.setText(cafeData.isOpen());
-        if (cafeData.isOpen().equals("Open")) {
-            cafeIsOpen.setTextColor(Color.parseColor("#7dd600"));
-        } else {
-            cafeIsOpen.setTextColor(Color.parseColor("#d82e41"));
+
+        if (cafeData.getCurrentStatus() == CafeteriaModel.Status.OPEN) {
+            cafeIsOpen.setText("Open");
+            cafeIsOpen.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.green));
+        } else if(cafeData.getCurrentStatus() == CafeteriaModel.Status.CLOSINGSOON){
+            cafeIsOpen.setText("Closing Soon");
+            cafeIsOpen.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.red));
+        } else{
+            cafeIsOpen.setText("Closed");
+            cafeIsOpen.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.red));
         }
 
         cafeText = findViewById(R.id.ind_time);

--- a/app/src/main/java/com/cornellappdev/android/eatery/WeeklyMenuActivity.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/WeeklyMenuActivity.java
@@ -196,7 +196,29 @@ public class WeeklyMenuActivity extends AppCompatActivity {
             }
         });
 
-        changeListAdapter("breakfast", 0);
+        // Selecting which menu to show based on the time of day
+        Date date = new Date();
+        if(date.getHours() < 11) {
+            changeListAdapter("breakfast", 0);
+            breakfastText.setTextColor(Color.parseColor("#000000"));
+            lunchText.setTextColor(Color.parseColor("#cdcdcd"));
+            dinnerText.setTextColor(Color.parseColor("#cdcdcd"));
+        } else if(date.getHours() < 16) {
+            changeListAdapter("lunch", 0);
+            breakfastText.setTextColor(Color.parseColor("#cdcdcd"));
+            lunchText.setTextColor(Color.parseColor("#000000"));
+            dinnerText.setTextColor(Color.parseColor("#cdcdcd"));
+        } else if(date.getHours() < 22) {
+            changeListAdapter("dinner", 0);
+            breakfastText.setTextColor(Color.parseColor("#cdcdcd"));
+            lunchText.setTextColor(Color.parseColor("#cdcdcd"));
+            dinnerText.setTextColor(Color.parseColor("#000000"));
+        } else{
+            changeListAdapter("breakfast", 1);
+            breakfastText.setTextColor(Color.parseColor("#000000"));
+            lunchText.setTextColor(Color.parseColor("#cdcdcd"));
+            dinnerText.setTextColor(Color.parseColor("#cdcdcd"));
+        }
 
         // Adds functionality to bottom nav bar
         bnv.setOnNavigationItemSelectedListener(new BottomNavigationView.OnNavigationItemSelectedListener() {
@@ -355,7 +377,6 @@ public class WeeklyMenuActivity extends AppCompatActivity {
                             dinnerList.put(m.getNickName(), n);
                         }
                     }
-
                 }
             }
         }

--- a/app/src/main/java/com/cornellappdev/android/eatery/WeeklyMenuActivity.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/WeeklyMenuActivity.java
@@ -294,38 +294,6 @@ public class WeeklyMenuActivity extends AppCompatActivity {
                 break;
         }
         changeListAdapter(mealType, selectedDate);
-//
-//        // Selecting which menu to show based on the time of day
-//        Date date = new Date();
-//        if(id == R.id.date0){
-//            if(date.getHours() < 11) {
-//                changeListAdapter("breakfast", 0);
-//                breakfastText.setTextColor(Color.parseColor("#000000"));
-//                lunchText.setTextColor(Color.parseColor("#cdcdcd"));
-//                dinnerText.setTextColor(Color.parseColor("#cdcdcd"));
-//            } else if(date.getHours() < 16) {
-//                changeListAdapter("lunch", 0);
-//                breakfastText.setTextColor(Color.parseColor("#cdcdcd"));
-//                lunchText.setTextColor(Color.parseColor("#000000"));
-//                dinnerText.setTextColor(Color.parseColor("#cdcdcd"));
-//            } else if(date.getHours() < 22) {
-//                changeListAdapter("dinner", 0);
-//                breakfastText.setTextColor(Color.parseColor("#cdcdcd"));
-//                lunchText.setTextColor(Color.parseColor("#cdcdcd"));
-//                dinnerText.setTextColor(Color.parseColor("#000000"));
-//            } else{
-//                changeListAdapter("breakfast", 1);
-//                breakfastText.setTextColor(Color.parseColor("#000000"));
-//                lunchText.setTextColor(Color.parseColor("#cdcdcd"));
-//                dinnerText.setTextColor(Color.parseColor("#cdcdcd"));
-//            }
-//        }
-//        else{
-//            changeListAdapter(mealType, selectedDate);
-//            breakfastText.setTextColor(Color.parseColor("#000000"));
-//            lunchText.setTextColor(Color.parseColor("#cdcdcd"));
-//            dinnerText.setTextColor(Color.parseColor("#cdcdcd"));
-//        }
     }
 
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/WeeklyMenuActivity.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/WeeklyMenuActivity.java
@@ -125,6 +125,16 @@ public class WeeklyMenuActivity extends AppCompatActivity {
         dateList.add((TextView) findViewById(R.id.date5));
         dateList.add((TextView) findViewById(R.id.date6));
 
+        // When changing date, highlight Breakfast textview
+        linDate.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                breakfastText.setTextColor(Color.parseColor("#000000"));
+                lunchText.setTextColor(Color.parseColor("#cdcdcd"));
+                dinnerText.setTextColor(Color.parseColor("#cdcdcd"));
+            }
+        });
+
         Date now = new Date();
         Calendar cal = Calendar.getInstance();
         cal.setTime(now);
@@ -196,25 +206,29 @@ public class WeeklyMenuActivity extends AppCompatActivity {
             }
         });
 
-        // Selecting which menu to show based on the time of day
+
         Date date = new Date();
         if(date.getHours() < 11) {
             changeListAdapter("breakfast", 0);
+            mealType = "breakfast";
             breakfastText.setTextColor(Color.parseColor("#000000"));
             lunchText.setTextColor(Color.parseColor("#cdcdcd"));
             dinnerText.setTextColor(Color.parseColor("#cdcdcd"));
         } else if(date.getHours() < 16) {
             changeListAdapter("lunch", 0);
+            mealType = "lunch";
             breakfastText.setTextColor(Color.parseColor("#cdcdcd"));
             lunchText.setTextColor(Color.parseColor("#000000"));
             dinnerText.setTextColor(Color.parseColor("#cdcdcd"));
         } else if(date.getHours() < 22) {
             changeListAdapter("dinner", 0);
+            mealType = "dinner";
             breakfastText.setTextColor(Color.parseColor("#cdcdcd"));
             lunchText.setTextColor(Color.parseColor("#cdcdcd"));
             dinnerText.setTextColor(Color.parseColor("#000000"));
         } else{
             changeListAdapter("breakfast", 1);
+            mealType = "breakfast";
             breakfastText.setTextColor(Color.parseColor("#000000"));
             lunchText.setTextColor(Color.parseColor("#cdcdcd"));
             dinnerText.setTextColor(Color.parseColor("#cdcdcd"));
@@ -255,6 +269,7 @@ public class WeeklyMenuActivity extends AppCompatActivity {
         changeDateColor(tv);
 
         int id = tv.getId();
+
         switch (id){
             case R.id.date0:
                 selectedDate = 0;
@@ -279,6 +294,38 @@ public class WeeklyMenuActivity extends AppCompatActivity {
                 break;
         }
         changeListAdapter(mealType, selectedDate);
+//
+//        // Selecting which menu to show based on the time of day
+//        Date date = new Date();
+//        if(id == R.id.date0){
+//            if(date.getHours() < 11) {
+//                changeListAdapter("breakfast", 0);
+//                breakfastText.setTextColor(Color.parseColor("#000000"));
+//                lunchText.setTextColor(Color.parseColor("#cdcdcd"));
+//                dinnerText.setTextColor(Color.parseColor("#cdcdcd"));
+//            } else if(date.getHours() < 16) {
+//                changeListAdapter("lunch", 0);
+//                breakfastText.setTextColor(Color.parseColor("#cdcdcd"));
+//                lunchText.setTextColor(Color.parseColor("#000000"));
+//                dinnerText.setTextColor(Color.parseColor("#cdcdcd"));
+//            } else if(date.getHours() < 22) {
+//                changeListAdapter("dinner", 0);
+//                breakfastText.setTextColor(Color.parseColor("#cdcdcd"));
+//                lunchText.setTextColor(Color.parseColor("#cdcdcd"));
+//                dinnerText.setTextColor(Color.parseColor("#000000"));
+//            } else{
+//                changeListAdapter("breakfast", 1);
+//                breakfastText.setTextColor(Color.parseColor("#000000"));
+//                lunchText.setTextColor(Color.parseColor("#cdcdcd"));
+//                dinnerText.setTextColor(Color.parseColor("#cdcdcd"));
+//            }
+//        }
+//        else{
+//            changeListAdapter(mealType, selectedDate);
+//            breakfastText.setTextColor(Color.parseColor("#000000"));
+//            lunchText.setTextColor(Color.parseColor("#cdcdcd"));
+//            dinnerText.setTextColor(Color.parseColor("#cdcdcd"));
+//        }
     }
 
 
@@ -383,6 +430,7 @@ public class WeeklyMenuActivity extends AppCompatActivity {
         finalList.add(breakfastList);
         finalList.add(lunchList);
         finalList.add(dinnerList);
+
         return finalList;
     }
 

--- a/app/src/main/res/layout/list_view_body.xml
+++ b/app/src/main/res/layout/list_view_body.xml
@@ -17,7 +17,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="#f2f2f2"
-        android:paddingTop="5dp"
         android:textSize="18sp"
         android:id="@+id/menu_title"/>
 


### PR DESCRIPTION
The closing time text view is now displayed as red, instead of green, in the main list 

The meal that is first displayed on the weekly menu now depends on the time of day (for example, if it's 12:00pm, the lunch menu is displayed first)

When pressing a new day in weekly menu, the meal that was previously displayed is displayed for the current day (ex. looking at lunch on Thursday 12th --> press Friday 13 --> displays Friday's lunch menu)

