### PR TITLE
Fixed filter button width

### DIFF
--- a/app/src/main/res/layout/fragment_main_list.xml
+++ b/app/src/main/res/layout/fragment_main_list.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".MainListFragment">
+             xmlns:tools="http://schemas.android.com/tools"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
+             tools:context=".MainListFragment">
 
     <RelativeLayout
         android:layout_width="match_parent"
@@ -21,117 +21,123 @@
                 android:id="@+id/linear"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
                 android:background="@color/white"
-                android:paddingRight="10dp"
+                android:orientation="horizontal"
                 android:paddingBottom="7dp">
 
                 <Button
                     android:id="@+id/northButton"
-                    android:layout_width="75dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
                     android:stateListAnimator="@null"
                     android:text="North"
                     android:textAllCaps="false"
                     android:textColor="@color/blue"
                     android:textSize="16sp"
-                    android:textStyle="normal" />
+                    android:textStyle="normal"/>
 
                 <Button
                     android:id="@+id/westButton"
-                    android:layout_width="75dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
                     android:stateListAnimator="@null"
                     android:text="West"
                     android:textAllCaps="false"
                     android:textColor="@color/blue"
                     android:textSize="16sp"
-                    android:textStyle="normal" />
+                    android:textStyle="normal"/>
 
                 <Button
                     android:id="@+id/centralButton"
-                    android:layout_width="75dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
                     android:stateListAnimator="@null"
                     android:text="Central"
                     android:textAllCaps="false"
                     android:textColor="@color/blue"
                     android:textSize="16sp"
-                    android:textStyle="normal" />
+                    android:textStyle="normal"/>
 
                 <Button
                     android:id="@+id/swipes"
-                    android:layout_width="75dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
                     android:stateListAnimator="@null"
                     android:text="Swipes"
                     android:textAllCaps="false"
                     android:textColor="@color/blue"
                     android:textSize="16sp"
-                    android:textStyle="normal" />
+                    android:textStyle="normal"/>
 
                 <Button
                     android:id="@+id/brb"
-                    android:layout_width="75dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
+                    android:layout_marginRight="8dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
                     android:stateListAnimator="@null"
                     android:text="BRB"
                     android:textAllCaps="false"
                     android:textColor="@color/blue"
                     android:textSize="16sp"
-                    android:textStyle="normal" />
+                    android:textStyle="normal"/>
 
                 <Button
                     android:id="@+id/american"
-                    android:layout_width="105dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
                     android:stateListAnimator="@null"
                     android:text="American"
@@ -139,19 +145,20 @@
                     android:textColor="@color/blue"
                     android:textSize="16sp"
                     android:textStyle="normal"
-                    android:visibility="gone" />
+                    android:visibility="gone"/>
 
                 <Button
                     android:id="@+id/chinese"
-                    android:layout_width="75dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
                     android:stateListAnimator="@null"
                     android:text="Chinese"
@@ -159,19 +166,20 @@
                     android:textColor="@color/blue"
                     android:textSize="16sp"
                     android:textStyle="normal"
-                    android:visibility="gone" />
+                    android:visibility="gone"/>
 
                 <Button
                     android:id="@+id/coffee"
-                    android:layout_width="75dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
                     android:stateListAnimator="@null"
                     android:text="Coffee"
@@ -179,19 +187,20 @@
                     android:textColor="@color/blue"
                     android:textSize="16sp"
                     android:textStyle="normal"
-                    android:visibility="gone" />
+                    android:visibility="gone"/>
 
                 <Button
                     android:id="@+id/desserts"
-                    android:layout_width="75dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
                     android:stateListAnimator="@null"
                     android:text="Desserts"
@@ -199,19 +208,20 @@
                     android:textColor="@color/blue"
                     android:textSize="16sp"
                     android:textStyle="normal"
-                    android:visibility="gone" />
+                    android:visibility="gone"/>
 
                 <Button
                     android:id="@+id/grocery"
-                    android:layout_width="75dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
                     android:stateListAnimator="@null"
                     android:text="Grocery"
@@ -219,20 +229,20 @@
                     android:textColor="@color/blue"
                     android:textSize="16sp"
                     android:textStyle="normal"
-                    android:visibility="gone" />
+                    android:visibility="gone"/>
 
                 <Button
                     android:id="@+id/indian"
-                    android:layout_width="75dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
-                    android:layout_marginRight="6dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
                     android:stateListAnimator="@null"
                     android:text="Indian"
@@ -240,19 +250,20 @@
                     android:textColor="@color/blue"
                     android:textSize="16sp"
                     android:textStyle="normal"
-                    android:visibility="gone" />
+                    android:visibility="gone"/>
 
                 <Button
                     android:id="@+id/italian"
-                    android:layout_width="75dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
                     android:stateListAnimator="@null"
                     android:text="Italian"
@@ -260,19 +271,20 @@
                     android:textColor="@color/blue"
                     android:textSize="16sp"
                     android:textStyle="normal"
-                    android:visibility="gone" />
+                    android:visibility="gone"/>
 
                 <Button
                     android:id="@+id/japanese"
-                    android:layout_width="95dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
                     android:stateListAnimator="@null"
                     android:text="Japanese"
@@ -280,19 +292,20 @@
                     android:textColor="@color/blue"
                     android:textSize="16sp"
                     android:textStyle="normal"
-                    android:visibility="gone" />
+                    android:visibility="gone"/>
 
                 <Button
                     android:id="@+id/korean"
-                    android:layout_width="75dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
                     android:stateListAnimator="@null"
                     android:text="Korean"
@@ -300,19 +313,20 @@
                     android:textColor="@color/blue"
                     android:textSize="16sp"
                     android:textStyle="normal"
-                    android:visibility="gone" />
+                    android:visibility="gone"/>
 
                 <Button
                     android:id="@+id/mediterranean"
-                    android:layout_width="125dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
                     android:stateListAnimator="@null"
                     android:text="Mediterranean"
@@ -320,19 +334,20 @@
                     android:textColor="@color/blue"
                     android:textSize="16sp"
                     android:textStyle="normal"
-                    android:visibility="gone" />
+                    android:visibility="gone"/>
 
                 <Button
                     android:id="@+id/thai"
-                    android:layout_width="75dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
                     android:stateListAnimator="@null"
                     android:text="Thai"
@@ -340,27 +355,30 @@
                     android:textColor="@color/blue"
                     android:textSize="16sp"
                     android:textStyle="normal"
-                    android:visibility="gone" />
+                    android:visibility="gone"/>
 
                 <Button
                     android:id="@+id/vietnamese"
-                    android:layout_width="105dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="40dp"
                     android:layout_marginLeft="8dp"
                     android:layout_marginTop="15dp"
+                    android:layout_marginRight="8dp"
                     android:layout_marginBottom="8dp"
-                    android:elevation="4dp"
                     android:background="@drawable/button"
+                    android:elevation="4dp"
                     android:fontFamily="sans-serif-medium"
                     android:gravity="center_horizontal"
+                    android:minWidth="75dp"
                     android:padding="8dp"
+                    android:paddingRight="30dp"
                     android:stateListAnimator="@null"
                     android:text="Vietnamese"
                     android:textAllCaps="false"
                     android:textColor="@color/blue"
                     android:textSize="16sp"
                     android:textStyle="normal"
-                    android:visibility="gone" />
+                    android:visibility="gone"/>
 
             </LinearLayout>
         </HorizontalScrollView>
@@ -371,7 +389,7 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/scroll"
             android:clipToPadding="false"
-            android:nestedScrollingEnabled="false" />
+            android:nestedScrollingEnabled="false"/>
 
         <LinearLayout
             android:id="@+id/pill_holder"
@@ -394,7 +412,7 @@
                     android:id="@+id/pill_campus"
                     android:layout_width="74dp"
                     android:layout_height="17dp"
-                    android:background="@drawable/pill_campus_active" />
+                    android:background="@drawable/pill_campus_active"/>
             </LinearLayout>
             <LinearLayout
                 android:id="@+id/pill_ctown_holder"
@@ -406,7 +424,7 @@
                     android:id="@+id/pill_collegetown"
                     android:layout_width="101dp"
                     android:layout_height="17dp"
-                    android:background="@drawable/pill_ct_inactive" />
+                    android:background="@drawable/pill_ct_inactive"/>
             </LinearLayout>
         </LinearLayout>
     </RelativeLayout>


### PR DESCRIPTION
Some of the text in the filter buttons were cut off because the width of the buttons were hardcoded: 
![image](https://user-images.githubusercontent.com/13595933/56387071-6de13880-61f1-11e9-8791-3a364f553b8f.png)


I changed the button width to `wrap_content` which fixed this issue: 
![image](https://user-images.githubusercontent.com/13595933/56387056-5c982c00-61f1-11e9-8d3e-fc02dc20c7aa.png)
