### PR TITLE
Standardized account info font sizes with other pages

### DIFF
--- a/app/src/main/res/layout/account_info_header.xml
+++ b/app/src/main/res/layout/account_info_header.xml
@@ -23,7 +23,7 @@
                 android:paddingBottom="12dp"
                 android:text="@string/accounts"
                 android:textColor="@color/primary"
-                android:textSize="30sp"
+                android:textSize="@dimen/account_info_header_text_size"
                 android:textStyle="bold"/>
             <LinearLayout
                 android:layout_width="match_parent"
@@ -39,7 +39,7 @@
                     android:paddingBottom="15dp"
                     android:text="@string/meal_swipes"
                     android:textColor="#222222"
-                    android:textSize="20sp"/>
+                    android:textSize="@dimen/account_info_attributes_text_size"/>
                 <TextView
                     android:id="@+id/swipesValue"
                     android:layout_width="match_parent"
@@ -49,7 +49,7 @@
                     android:gravity="end"
                     android:text=""
                     android:textColor="#7d8288"
-                    android:textSize="16sp"/>
+                    android:textSize="@dimen/account_info_attributes_text_size"/>
             </LinearLayout>
             <LinearLayout
                 android:layout_width="match_parent"
@@ -65,7 +65,7 @@
                     android:paddingBottom="15dp"
                     android:text="@string/brbs"
                     android:textColor="#222222"
-                    android:textSize="20sp"
+                    android:textSize="@dimen/account_info_attributes_text_size"
                 />
                 <TextView
                     android:id="@+id/brbValue"
@@ -76,7 +76,7 @@
                     android:gravity="end"
                     android:text=""
                     android:textColor="#7d8288"
-                    android:textSize="16sp"/>
+                    android:textSize="@dimen/account_info_attributes_text_size"/>
             </LinearLayout>
             <LinearLayout
                 android:layout_width="match_parent"
@@ -92,7 +92,7 @@
                     android:paddingBottom="15dp"
                     android:text="@string/city_bucks"
                     android:textColor="#222222"
-                    android:textSize="18sp"
+                    android:textSize="@dimen/account_info_attributes_text_size"
                 />
                 <TextView
                     android:id="@+id/cityBucksValue"
@@ -103,7 +103,7 @@
                     android:gravity="end"
                     android:text=""
                     android:textColor="#7d8288"
-                    android:textSize="16sp"/>
+                    android:textSize="@dimen/account_info_attributes_text_size"/>
             </LinearLayout>
             <LinearLayout
                 android:layout_width="match_parent"
@@ -119,7 +119,7 @@
                     android:paddingBottom="20dp"
                     android:text="@string/laundry"
                     android:textColor="#222222"
-                    android:textSize="20sp"
+                    android:textSize="@dimen/account_info_attributes_text_size"
                 />
                 <TextView
                     android:id="@+id/laundryValue"
@@ -130,7 +130,7 @@
                     android:gravity="end"
                     android:text=""
                     android:textColor="#7d8288"
-                    android:textSize="17sp"/>
+                    android:textSize="@dimen/account_info_attributes_text_size"/>
             </LinearLayout>
             <TextView
                 android:id="@+id/history"
@@ -142,7 +142,7 @@
                 android:paddingBottom="12dp"
                 android:text="@string/history"
                 android:textColor="@color/primary"
-                android:textSize="30dp"
+                android:textSize="@dimen/account_info_header_text_size"
                 android:textStyle="bold"/>
         </LinearLayout>
     </RelativeLayout>

--- a/app/src/main/res/layout/activity_campus_eatery.xml
+++ b/app/src/main/res/layout/activity_campus_eatery.xml
@@ -157,7 +157,7 @@
                 android:paddingBottom="12dp"
                 android:text="Menu"
                 android:textColor="@color/primary"
-                android:textSize="16dp"/>
+                android:textSize="16sp"/>
 
             <LinearLayout
                 android:id="@+id/linear"

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -28,7 +28,7 @@
                 android:paddingRight="15dp"
                 android:text="@string/description_header"
                 android:textColor="@color/primary"
-                android:textSize="20sp"
+                android:textSize="@dimen/account_info_header_text_size"
                 android:textStyle="normal"/>
 
             <TextView
@@ -42,7 +42,7 @@
                 android:paddingRight="15dp"
                 android:text="@string/description_text_1"
                 android:textColor="@color/primary"
-                android:textSize="18sp"
+                android:textSize="@dimen/account_info_attributes_text_size"
                 android:textStyle="normal"/>
 
             <TextView
@@ -55,7 +55,7 @@
                 android:paddingRight="15dp"
                 android:text="@string/description_text_2"
                 android:textColor="@color/primary"
-                android:textSize="18sp"
+                android:textSize="@dimen/account_info_attributes_text_size"
                 android:textStyle="normal"/>
 
             <TextView
@@ -68,7 +68,7 @@
                 android:paddingRight="15dp"
                 android:text="@string/appdev_website"
                 android:textColor="@color/blue"
-                android:textSize="20sp"
+                android:textSize="@dimen/account_info_attributes_text_size"
                 android:textStyle="normal"/>
 
             <TextView
@@ -81,7 +81,7 @@
                 android:paddingRight="15dp"
                 android:text="@string/feedback_header"
                 android:textColor="@color/primary"
-                android:textSize="20sp"
+                android:textSize="@dimen/account_info_header_text_size"
                 android:textStyle="normal"/>
 
             <TextView
@@ -94,7 +94,7 @@
                 android:paddingRight="15dp"
                 android:text="@string/feedback_text"
                 android:textColor="@color/primary"
-                android:textSize="18sp"
+                android:textSize="@dimen/account_info_attributes_text_size"
                 android:textStyle="normal"/>
 
             <TextView
@@ -108,7 +108,7 @@
                 android:paddingBottom="20dp"
                 android:text="@string/google_form"
                 android:textColor="@color/blue"
-                android:textSize="20sp"
+                android:textSize="@dimen/account_info_attributes_text_size"
                 android:textStyle="normal"/>
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -22,7 +22,7 @@
             android:paddingEnd="25dp"
             android:text="@string/description_text_1"
             android:textColor="@color/primary"
-            android:textSize="16sp"
+            android:textSize="@dimen/account_info_attributes_text_size"
             android:textStyle="bold"/>
 
         <TextView
@@ -35,7 +35,7 @@
             android:paddingEnd="20dp"
             android:text="@string/netid"
             android:textColor="@color/primary"
-            android:textSize="18sp"
+            android:textSize="@dimen/account_info_attributes_text_size"
             android:textStyle="bold"/>
 
         <EditText
@@ -50,7 +50,7 @@
             android:inputType="textPersonName"
             android:paddingTop="15dp"
             android:paddingBottom="20dp"
-            android:textSize="19sp"/>
+            android:textSize="@dimen/account_info_attributes_text_size"/>
 
         <TextView
             android:id="@+id/passwordLabel"
@@ -61,7 +61,7 @@
             android:paddingTop="15dp"
             android:text="@string/password"
             android:textColor="@color/primary"
-            android:textSize="18sp"
+            android:textSize="@dimen/account_info_attributes_text_size"
             android:textStyle="bold"/>
 
         <EditText
@@ -77,7 +77,7 @@
             android:inputType="textPassword"
             android:paddingTop="15dp"
             android:paddingBottom="20dp"
-            android:textSize="19sp"/>
+            android:textSize="@dimen/account_info_attributes_text_size"/>
 
         <LinearLayout
             android:layout_width="wrap_content"
@@ -93,7 +93,7 @@
                 android:lineSpacingExtra="3sp"
                 android:text="@string/auto_login"
                 android:textColor="@color/primary"
-                android:textSize="16sp"
+                android:textSize="@dimen/account_info_attributes_text_size"
                 android:textStyle="bold"
             />
             <CheckBox
@@ -138,7 +138,7 @@
             android:paddingTop="25dp"
             android:text="@string/privacy_statement"
             android:textColor="@color/blue"
-            android:textSize="16sp"/>
+            android:textSize="@dimen/account_info_attributes_text_size"/>
     </LinearLayout>
 
 

--- a/app/src/main/res/layout/fragment_logout.xml
+++ b/app/src/main/res/layout/fragment_logout.xml
@@ -29,7 +29,7 @@
                 android:paddingBottom="20dp"
                 android:text="Settings"
                 android:textColor="@color/primary"
-                android:textSize="23sp"
+                android:textSize="@dimen/account_info_header_text_size"
                 android:textStyle="bold"/>
             <RelativeLayout
                 android:id="@+id/about_segway"
@@ -52,7 +52,7 @@
                     android:text="@string/about"
                     android:textAllCaps="false"
                     android:textColor="@color/primary"
-                    android:textSize="19sp"
+                    android:textSize="@dimen/account_info_attributes_text_size"
                 />
                 <LinearLayout
                     android:layout_width="wrap_content"
@@ -89,7 +89,7 @@
                     android:text="@string/auto_login"
                     android:textAllCaps="false"
                     android:textColor="@color/primary"
-                    android:textSize="19sp"
+                    android:textSize="@dimen/account_info_attributes_text_size"
                 />
                 <CheckBox
                     android:id="@+id/saveCheckInfo"
@@ -120,7 +120,7 @@
                     android:text="@string/logout_label"
                     android:textAllCaps="true"
                     android:textColor="@color/blue"
-                    android:textSize="18sp"
+                    android:textSize="@dimen/account_info_attributes_text_size"
                     android:textStyle="bold"
                 />
             </RelativeLayout>

--- a/app/src/main/res/layout/fragment_weekly_menu.xml
+++ b/app/src/main/res/layout/fragment_weekly_menu.xml
@@ -183,7 +183,7 @@
                 android:paddingBottom="12dp"
                 android:text="North Campus"
                 android:textColor="@color/primary"
-                android:textSize="30dp"
+                android:textSize="30sp"
                 android:textStyle="bold"/>
 
             <com.cornellappdev.android.eatery.NonScrollExpandableListView

--- a/app/src/main/res/layout/history_item.xml
+++ b/app/src/main/res/layout/history_item.xml
@@ -25,7 +25,7 @@
                 android:paddingTop="15dp"
                 android:paddingEnd="15dp"
                 android:textColor="#222222"
-                android:textSize="20sp"/>
+                android:textSize="@dimen/account_info_attributes_text_size"/>
 
             <TextView
                 android:id="@+id/purchase_timestamp"
@@ -37,7 +37,7 @@
                 android:paddingEnd="15dp"
                 android:paddingBottom="20dp"
                 android:textColor="#888888"
-                android:textSize="16sp"/>
+                android:textSize="@dimen/account_info_attributes_sub_text_size"/>
         </LinearLayout>
         <TextView
             android:id="@+id/purchase_amount"
@@ -49,6 +49,6 @@
             android:paddingTop="30dp"
             android:paddingEnd="25dp"
             android:textColor="#f2655d"
-            android:textSize="17sp"/>
+            android:textSize="@dimen/account_info_attributes_text_size"/>
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,4 +2,8 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <dimen name="design_bottom_navigation_text_size" tools:override="true">14sp</dimen>
     <dimen name="design_bottom_navigation_active_text_size" tools:override="true">14sp</dimen>
+
+    <dimen name="account_info_header_text_size" tools:override="true">30sp</dimen>
+    <dimen name="account_info_attributes_text_size" tools:override="true">16sp</dimen>
+    <dimen name="account_info_attributes_sub_text_size" tools:override="true">14sp</dimen>
 </resources>


### PR DESCRIPTION
## Overview
Various font sizing changes in the accounts page/flow.

## Changes Made
- Made title and body font sizes consistent with those on other pages (header being `30sp`, body being `16sp`
 - Factored out text sizes into `dimens.xml` to make future changes easier
 - Replaced `dp` font sizes with `sp` so that they will scale with user preferences

## Test Coverage
 - No changes in testing needed since only font sizes were edited.
 - Ran it on several emulators with no issues, I don't have BRBs/swipes anymore so I can't test the `History`

## Next Steps
 - Probably worth bringing a designer in to audit the font sizes, this would also make it easier to factor out font sizes across the app

## Screenshots

<details>

  <summary>Main Account Page</summary>


<img width="307" alt="Screen Shot 2019-09-15 at 6 56 51 PM" src="https://user-images.githubusercontent.com/35942769/64928767-ae69d000-d7ea-11e9-92e5-d3b07d160fc3.png">
  

</details>

<details>

  <summary>Log out Page</summary>


<img width="307" alt="Screen Shot 2019-09-15 at 6 57 00 PM" src="https://user-images.githubusercontent.com/35942769/64928795-db1de780-d7ea-11e9-8c8f-34a6bd1e6a91.png">


</details>

<details>

  <summary>About Page</summary>


<img width="307" alt="Screen Shot 2019-09-15 at 6 57 05 PM" src="https://user-images.githubusercontent.com/35942769/64928801-ed982100-d7ea-11e9-9bc7-59877527365c.png">

  

</details>
