### PR TITLE
Remove statement 3 of privacy statement

### DIFF
--- a/app/src/main/res/layout/fragment_privacy.xml
+++ b/app/src/main/res/layout/fragment_privacy.xml
@@ -57,20 +57,6 @@
                 android:textColor="@color/primary"
                 android:textSize="16sp"
                 android:textStyle="normal"/>
-            <TextView
-                android:id="@+id/privacy3"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:fontFamily="sans-serif"
-                android:gravity="center"
-                android:paddingStart="30dp"
-                android:paddingTop="20dp"
-                android:paddingEnd="30dp"
-                android:text="@string/privacy_description_3"
-                android:textColor="@color/primary"
-                android:textSize="16sp"
-                android:textStyle="normal"/>
         </LinearLayout>
     </ScrollView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,10 +32,7 @@
         be stored safely on this device.
     </string>
     <string name="privacy_description_2">Your netid and password will never leave your device, and
-        will never be stored on our servers or viewed by anyone on our team
-    </string>
-    <string name="privacy_description_3">You may uncheck auto login to erase all of your account
-        information from this device
+        will never be stored on our servers or viewed by anyone on our team.
     </string>
     <string name="login_label">Login</string>
     <string name="logout_label">Logout</string>


### PR DESCRIPTION
Update privacy statement to be consistent with the new mechanism of logging in on Android

<!-- Summarize your changes here. -->

## Changes Made

Removed privacy statement 3, which was along the lines of "unchecking auto-login will remove all account data stored on this device" - it was both confusing and inapplicable bc we removed auto-login.

## Test Coverage

Simulator

## Related PRs or Issues (delete if not applicable)

Addresses #157 

## Screenshots (delete if not applicable)

<!-- If you are making any changes to UI, you should use this section. -->

<details>

Updated privacy statement

![image](https://user-images.githubusercontent.com/44482245/68359547-3cc34980-00ea-11ea-8889-ba3946d6da1d.png)

  

</details>
