### PR TITLE
Connor/positive transactions

### DIFF
--- a/app/src/main/graphql/com/cornellappdev/android/eatery/brbQuery.graphql
+++ b/app/src/main/graphql/com/cornellappdev/android/eatery/brbQuery.graphql
@@ -7,6 +7,7 @@ query BrbInfo($accountId: String) {
         history {
 	    amount
             name
+	    positive
             timestamp
         }
     }

--- a/app/src/main/graphql/com/cornellappdev/android/eatery/schema.json
+++ b/app/src/main/graphql/com/cornellappdev/android/eatery/schema.json
@@ -288,6 +288,20 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "positive",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+          }
           }
         ],
         "inputFields": null,

--- a/app/src/main/java/com/cornellappdev/android/eatery/loginviews/HistoryInfoAdapter.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/loginviews/HistoryInfoAdapter.java
@@ -7,6 +7,8 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
 
+import androidx.core.content.ContextCompat;
+
 import com.cornellappdev.android.eatery.R;
 import com.cornellappdev.android.eatery.model.HistoryObjectModel;
 import com.cornellappdev.android.eatery.util.MoneyUtil;
@@ -50,11 +52,18 @@ public class HistoryInfoAdapter extends ArrayAdapter<HistoryObjectModel> {
             } else {
                 holder = (ViewHolder) historyItemView.getTag();
             }
-
+            String displayText;
+            if(mHistory.get(position).isPositive()) {
+               displayText = "+" + MoneyUtil.toMoneyString(mHistory.get(position).getAmount());
+               holder.displayAmount.setTextColor(ContextCompat.getColor(getContext(), R.color.green));
+            }
+            else {
+                displayText = "-" + MoneyUtil.toMoneyString(mHistory.get(position).getAmount());
+                holder.displayAmount.setTextColor(ContextCompat.getColor(getContext(), R.color.red));
+            }
+            holder.displayAmount.setText(displayText);
             holder.displayName.setText(mHistory.get(position).getName());
             holder.displayTimestamp.setText(mHistory.get(position).getTimestamp());
-            holder.displayAmount.setText(
-                    "- " + MoneyUtil.toMoneyString(mHistory.get(position).getAmount()));
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/app/src/main/java/com/cornellappdev/android/eatery/loginviews/HistoryInfoAdapter.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/loginviews/HistoryInfoAdapter.java
@@ -53,12 +53,13 @@ public class HistoryInfoAdapter extends ArrayAdapter<HistoryObjectModel> {
                 holder = (ViewHolder) historyItemView.getTag();
             }
             String displayText;
+            String amount = MoneyUtil.toMoneyString(mHistory.get(position).getAmount());
             if(mHistory.get(position).isPositive()) {
-               displayText = "+" + MoneyUtil.toMoneyString(mHistory.get(position).getAmount());
+               displayText = String.format("+%s", amount);
                holder.displayAmount.setTextColor(ContextCompat.getColor(getContext(), R.color.green));
             }
             else {
-                displayText = "-" + MoneyUtil.toMoneyString(mHistory.get(position).getAmount());
+                displayText = String.format("-%s", amount);
                 holder.displayAmount.setTextColor(ContextCompat.getColor(getContext(), R.color.red));
             }
             holder.displayAmount.setText(displayText);

--- a/app/src/main/java/com/cornellappdev/android/eatery/model/HistoryObjectModel.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/model/HistoryObjectModel.java
@@ -9,20 +9,26 @@ public class HistoryObjectModel implements Serializable {
     private String mName;
     private String mTimestamp;
     private float mAmount;
+    private boolean mPositive;
 
-    public HistoryObjectModel(String name, String timestamp, float amount) {
+    public HistoryObjectModel(String name, String timestamp, float amount, boolean positive) {
         this.mName = name;
         this.mTimestamp = timestamp;
         this.mAmount = amount;
+        this.mPositive = positive;
     }
 
     public static HistoryObjectModel parseHistoryObject(BrbInfoQuery.History historyInfo) {
         String name = historyInfo.name();
         String timestamp = historyInfo.timestamp();
         float amount = Float.parseFloat(historyInfo.amount());
-        return new HistoryObjectModel(name, timestamp, amount);
+        boolean positive = historyInfo.positive();
+        return new HistoryObjectModel(name, timestamp, amount, positive);
     }
 
+    public boolean isPositive() {
+        return mPositive;
+    }
     public String getName() {
         return mName;
     }

--- a/app/src/main/res/layout/fragment_privacy.xml
+++ b/app/src/main/res/layout/fragment_privacy.xml
@@ -57,20 +57,6 @@
                 android:textColor="@color/primary"
                 android:textSize="16sp"
                 android:textStyle="normal"/>
-            <TextView
-                android:id="@+id/privacy3"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:fontFamily="sans-serif"
-                android:gravity="center"
-                android:paddingStart="30dp"
-                android:paddingTop="20dp"
-                android:paddingEnd="30dp"
-                android:text="@string/privacy_description_3"
-                android:textColor="@color/primary"
-                android:textSize="16sp"
-                android:textStyle="normal"/>
         </LinearLayout>
     </ScrollView>
 

--- a/app/src/main/res/layout/history_item.xml
+++ b/app/src/main/res/layout/history_item.xml
@@ -43,7 +43,7 @@
             android:id="@+id/purchase_amount"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:fontFamily="sans-serif-medium"
+            android:fontFamily="sans-serif"
             android:gravity="end"
             android:paddingStart="25dp"
             android:paddingTop="30dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,10 +32,7 @@
         be stored safely on this device.
     </string>
     <string name="privacy_description_2">Your netid and password will never leave your device, and
-        will never be stored on our servers or viewed by anyone on our team
-    </string>
-    <string name="privacy_description_3">You may uncheck auto login to erase all of your account
-        information from this device
+        will never be stored on our servers or viewed by anyone on our team.
     </string>
     <string name="login_label">Login</string>
     <string name="logout_label">Logout</string>


### PR DESCRIPTION
## Overview

This PR adds support for positive transactions when viewing purchase history in Get. Beforehand, we assumed every transaction was negative and displayed a -$<dollar amount> for each transaction, but this PR checks to see if the transaction was positive and changes color green if so



## Changes Made

Updated brbQuery.graphql to include a positive field in history of Get. Updated schema.json to reflect this positive field. Added an instance variable to the model reflecting whether it is positive or not. When displaying the value in their history, check to see whether this instance variable is positive or not and act accordingly

## Test Coverage

Ran on simulator and tested on test device

## Related PRs or Issues (delete if not applicable)

Addresses issue #166 

## Screenshots

  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
![image](https://user-images.githubusercontent.com/44482245/68361567-58325280-00f2-11ea-9797-bb2ddd50984c.png)

