### PR TITLE
Move private information to keys.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ build/
 app/src/main/res/values/google_maps_api.xml
 .DS_Store
 google-services.json
+
+# Private Information
+keys.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.apollographql.android'
 
+def keyFile = file('../keys.properties')
+def keyProperties = new Properties()
+keyProperties.load(new FileInputStream(keyFile))
 
 android {
     compileSdkVersion 28
@@ -11,6 +14,9 @@ android {
         versionCode 38
         versionName "2.5.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        resValue 'string', "google_maps_key", keyProperties["googleMapApiKey"]
+        resValue 'string', "encryption_key", keyProperties['encryptionKey']
+        resValue 'string', "encryption_salt", keyProperties['encryptionSalt']
     }
     buildTypes {
         release {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,9 +122,4 @@
     <string name="city_bucks">City Bucks</string>
     <string name="laundry">Laundry</string>
     <string name="history">History</string>
-
-    <!-- Below values need to be updated before each launch -->
-    <string name="encryption_key">a</string>
-    <string name="encryption_salt">a</string>
-    <string name="google_maps_key">a</string>
 </resources>


### PR DESCRIPTION
Moved API key information and encryption salt + sugar over to a new keys.properties file. This should prevent mishaps where this information is accidentally pushed to GitHub. New developers now need to manually add keys.properties to their project upon cloning the repository.

Added keys.properties to .gitignore