### PR TITLE
AndroidX migration and targetsdk and compilesdk are now version 29

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,14 +6,14 @@ def keyProperties = new Properties()
 keyProperties.load(new FileInputStream(keyFile))
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.cornellappdev.android.eatery"
         minSdkVersion 26
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 38
         versionName "2.5.1"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         resValue 'string', "google_maps_key", keyProperties["googleMapApiKey"]
         resValue 'string', "encryption_key", keyProperties['encryptionKey']
         resValue 'string', "encryption_salt", keyProperties['encryptionSalt']
@@ -38,23 +38,23 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.apollographql.apollo:apollo-runtime:1.1.3'
     implementation 'com.apollographql.apollo:apollo-android-support:1.1.3'
-    implementation 'com.google.firebase:firebase-analytics:17.2.0'
-    implementation 'com.android.support:design:28.0.0'
-    implementation 'com.android.support:support-v4:28.0.0'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'com.google.firebase:firebase-analytics:17.5.0'
+    implementation 'com.google.android.material:material:1.2.1'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.recyclerview:recyclerview:1.1.0-beta04'
-    implementation 'androidx.exifinterface:exifinterface:1.1.0-beta01'
+    implementation 'androidx.recyclerview:recyclerview:1.2.0-alpha06'
+    implementation 'androidx.exifinterface:exifinterface:1.3.0'
     implementation 'org.jetbrains:annotations:16.0.2'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
     implementation "com.airbnb.android:lottie:3.2.2"
 
-    implementation 'com.google.android.gms:play-services-maps:15.0.0'
+    implementation 'com.google.android.gms:play-services-maps:17.0.0'
     implementation 'com.squareup.picasso:picasso:2.71828'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.google.gms:google-services:4.2.0'
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath 'com.apollographql.apollo:apollo-gradle-plugin:1.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 09 00:13:04 EDT 2019
+#Sun Oct 04 15:43:17 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION


## Overview
Android target SDK change to version 29, and migration to AndroidX libraries.



## Changes Made

Changes in build.gradle and refactored project to migrate to AndroidX. Updated the newest versions as well.



## Test Coverage

Tested on Pixel 3a emulator API 30 and Oneplus 7 Pro phone API 29

