### PR TITLE
Expanded Menus Feature, New Backend Queries and Parsing, Base Model Update, Intent Rebasing, and Major Design Changes.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,6 @@ dependencies {
     implementation 'org.jetbrains:annotations:16.0.2'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
     implementation "com.airbnb.android:lottie:3.2.2"
-
     implementation 'com.google.android.gms:play-services-maps:17.0.0'
     implementation 'com.squareup.picasso:picasso:2.71828'
     testImplementation 'junit:junit:4.12'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.cornellappdev.android.eatery"
         minSdkVersion 26
         targetSdkVersion 29
-        versionCode 43
-        versionName "2.6.3"
+        versionCode 44
+        versionName "2.7.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         resValue 'string', "google_maps_key", keyProperties["googleMapApiKey"]
         resValue 'string', "encryption_key", keyProperties['encryptionKey']

--- a/app/src/main/graphql/com/cornellappdev/android/eatery/eateryQuery.graphql
+++ b/app/src/main/graphql/com/cornellappdev/android/eatery/eateryQuery.graphql
@@ -12,6 +12,22 @@ query AllEateries {
         location
         reserveUrl
         isGet
+        expandedMenu{
+            stations {
+                items {
+                    item,
+                    price,
+                    healthy,
+                    choices {
+                        options,
+                        label
+                    },
+                    favorite
+                },
+                category
+            }
+            category
+        }
         campusArea {
             descriptionShort
         }

--- a/app/src/main/graphql/com/cornellappdev/android/eatery/schema.json
+++ b/app/src/main/graphql/com/cornellappdev/android/eatery/schema.json
@@ -11,6 +11,7 @@
         "kind": "OBJECT",
         "name": "Query",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "accountInfo",
@@ -24,7 +25,9 @@
                   "name": "String",
                   "ofType": null
                 },
-                "defaultValue": null
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -47,7 +50,25 @@
                   "name": "Int",
                   "ofType": null
                 },
-                "defaultValue": null
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "favorites",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -74,7 +95,9 @@
                   "name": "Int",
                   "ofType": null
                 },
-                "defaultValue": null
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -101,7 +124,25 @@
                   "name": "Int",
                   "ofType": null
                 },
-                "defaultValue": null
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "favorites",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -126,6 +167,7 @@
         "kind": "OBJECT",
         "name": "AccountInfoType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "brbs",
@@ -221,6 +263,7 @@
         "kind": "SCALAR",
         "name": "String",
         "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+        "specifiedByUrl": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -231,6 +274,7 @@
         "kind": "OBJECT",
         "name": "TransactionType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "amount",
@@ -306,6 +350,7 @@
         "kind": "SCALAR",
         "name": "Boolean",
         "description": "The `Boolean` scalar type represents `true` or `false`.",
+        "specifiedByUrl": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -316,6 +361,7 @@
         "kind": "OBJECT",
         "name": "CampusEateryType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "coordinates",
@@ -647,6 +693,7 @@
         "kind": "OBJECT",
         "name": "CoordinatesType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "latitude",
@@ -690,6 +737,7 @@
         "kind": "SCALAR",
         "name": "Float",
         "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+        "specifiedByUrl": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -700,6 +748,7 @@
         "kind": "SCALAR",
         "name": "Int",
         "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+        "specifiedByUrl": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -710,6 +759,7 @@
         "kind": "OBJECT",
         "name": "PaymentMethodsType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "brbs",
@@ -817,6 +867,7 @@
         "kind": "ENUM",
         "name": "PaymentMethodsEnum",
         "description": null,
+        "specifiedByUrl": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -864,6 +915,7 @@
         "kind": "OBJECT",
         "name": "CampusAreaType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "descriptionShort",
@@ -891,6 +943,7 @@
         "kind": "OBJECT",
         "name": "FoodCategoryType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "category",
@@ -938,6 +991,7 @@
         "kind": "OBJECT",
         "name": "DescriptiveFoodStationType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "category",
@@ -985,6 +1039,7 @@
         "kind": "OBJECT",
         "name": "DescriptiveFoodItemType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "item",
@@ -1004,6 +1059,22 @@
           },
           {
             "name": "healthy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "favorite",
             "description": null,
             "args": [],
             "type": {
@@ -1060,6 +1131,7 @@
         "kind": "OBJECT",
         "name": "DescriptiveFoodItemOptionType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "label",
@@ -1107,6 +1179,7 @@
         "kind": "OBJECT",
         "name": "OperatingHoursType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "date",
@@ -1154,6 +1227,7 @@
         "kind": "OBJECT",
         "name": "EventType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "calSummary",
@@ -1249,6 +1323,7 @@
         "kind": "OBJECT",
         "name": "FoodStationType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "category",
@@ -1296,6 +1371,7 @@
         "kind": "OBJECT",
         "name": "FoodItemType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "item",
@@ -1328,6 +1404,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "favorite",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -1339,6 +1431,7 @@
         "kind": "OBJECT",
         "name": "SwipeDataType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "endTime",
@@ -1446,6 +1539,7 @@
         "kind": "OBJECT",
         "name": "CollegetownEateryType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "coordinates",
@@ -1709,6 +1803,7 @@
         "kind": "OBJECT",
         "name": "CollegetownHoursType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "date",
@@ -1756,6 +1851,7 @@
         "kind": "OBJECT",
         "name": "CollegetownEventType",
         "description": null,
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "description",
@@ -1815,6 +1911,7 @@
         "kind": "ENUM",
         "name": "RatingEnum",
         "description": null,
+        "specifiedByUrl": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -1880,6 +1977,7 @@
         "kind": "OBJECT",
         "name": "__Schema",
         "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "description",
@@ -1991,6 +2089,7 @@
         "kind": "OBJECT",
         "name": "__Type",
         "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedByUrl`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "kind",
@@ -2056,7 +2155,9 @@
                   "name": "Boolean",
                   "ofType": null
                 },
-                "defaultValue": "false"
+                "defaultValue": "false",
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -2127,7 +2228,9 @@
                   "name": "Boolean",
                   "ofType": null
                 },
-                "defaultValue": "false"
+                "defaultValue": "false",
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -2158,7 +2261,9 @@
                   "name": "Boolean",
                   "ofType": null
                 },
-                "defaultValue": "false"
+                "defaultValue": "false",
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -2199,6 +2304,7 @@
         "kind": "ENUM",
         "name": "__TypeKind",
         "description": "An enum describing what kind of type a given `__Type` is.",
+        "specifiedByUrl": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -2258,6 +2364,7 @@
         "kind": "OBJECT",
         "name": "__Field",
         "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "name",
@@ -2299,7 +2406,9 @@
                   "name": "Boolean",
                   "ofType": null
                 },
-                "defaultValue": "false"
+                "defaultValue": "false",
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -2376,6 +2485,7 @@
         "kind": "OBJECT",
         "name": "__InputValue",
         "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "name",
@@ -2471,6 +2581,7 @@
         "kind": "OBJECT",
         "name": "__EnumValue",
         "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "name",
@@ -2538,6 +2649,7 @@
         "kind": "OBJECT",
         "name": "__Directive",
         "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+        "specifiedByUrl": null,
         "fields": [
           {
             "name": "name",
@@ -2641,6 +2753,7 @@
         "kind": "ENUM",
         "name": "__DirectiveLocation",
         "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+        "specifiedByUrl": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -2786,7 +2899,9 @@
                 "ofType": null
               }
             },
-            "defaultValue": null
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ]
       },
@@ -2812,7 +2927,9 @@
                 "ofType": null
               }
             },
-            "defaultValue": null
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ]
       }

--- a/app/src/main/java/com/cornellappdev/android/eatery/CampusMenuActivity.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/CampusMenuActivity.java
@@ -7,9 +7,7 @@ import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.Gravity;
-import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
@@ -20,17 +18,14 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.LinearLayoutCompat;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
 import androidx.core.widget.NestedScrollView;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
-
 import com.cornellappdev.android.eatery.components.CustomPager;
 import com.cornellappdev.android.eatery.components.WaitTimesComponent;
 import com.cornellappdev.android.eatery.model.CafeModel;
@@ -48,9 +43,7 @@ import com.google.android.material.tabs.TabLayout;
 import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class CampusMenuActivity extends AppCompatActivity {
     TextView mCafeText;
@@ -301,8 +294,9 @@ public class CampusMenuActivity extends AppCompatActivity {
                             mExpandedTabLayout.setTabMode(TabLayout.MODE_FIXED);
                             mExpandedTabLayout.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT,
                                     LinearLayout.LayoutParams.WRAP_CONTENT));
+                        }
                     }
-                }});
+                });
 
                 List<View> containers = new ArrayList<>();
                 for (int i = 0; i < menu.size(); i++) {

--- a/app/src/main/java/com/cornellappdev/android/eatery/CampusMenuActivity.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/CampusMenuActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -41,7 +42,9 @@ import com.google.android.material.tabs.TabLayout;
 import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class CampusMenuActivity extends AppCompatActivity {
     TextView mCafeText;
@@ -60,6 +63,7 @@ public class CampusMenuActivity extends AppCompatActivity {
     CollapsingToolbarLayout mCollapsingToolbar;
     NestedScrollView mScrollView;
     private TabLayout mTabLayout;
+    private TabLayout mExpandedTabLayout;
     private MenuPresenter mMenuPresenter;
 
     @Override
@@ -237,6 +241,7 @@ public class CampusMenuActivity extends AppCompatActivity {
 
         CustomPager customPager = findViewById(R.id.pager);
         mTabLayout = findViewById(R.id.tabs);
+        mExpandedTabLayout = findViewById(R.id.expandedTabs);
         mLinLayout = findViewById(R.id.linear);
 
         float scale = getResources().getDisplayMetrics().density;
@@ -245,6 +250,7 @@ public class CampusMenuActivity extends AppCompatActivity {
         if (mCafeData instanceof CafeModel) {
             customPager.setVisibility(View.GONE);
             mTabLayout.setVisibility(View.GONE);
+            mExpandedTabLayout.setVisibility(View.VISIBLE);
             mLinLayout.setVisibility(View.VISIBLE);
 
             View blank = new View(this);
@@ -255,10 +261,18 @@ public class CampusMenuActivity extends AppCompatActivity {
             blank.setElevation(-1);
             mLinLayout.addView(blank);
 
-            List<String> menu = ((CafeModel) mCafeData).getCafeMenu();
-            for (int i = 0; i < menu.size(); i++) {
+            mExpandedTabLayout.setupWithViewPager(customPager);
+            mExpandedTabLayout.setTabTextColors(
+                    ContextCompat.getColor(getApplicationContext(), R.color.primary),
+                    ContextCompat.getColor(getApplicationContext(), R.color.blue));
+
+            HashMap<String, String> menu = ((CafeModel) mCafeData).getExpandedMenuItems();
+            HashMap<String, Integer> categories = ((CafeModel) mCafeData).getExpandedMenuStations();
+            for (Map.Entry<String, String> entry : menu.entrySet()) {
+                String name = entry.getKey();
+                String price = entry.getValue();
                 TextView mealItemText = new TextView(this);
-                mealItemText.setText(menu.get(i));
+                mealItemText.setText(name);
                 mealItemText.setTextSize(14);
                 mealItemText.setTextColor(
                         ContextCompat.getColor(getApplicationContext(), R.color.primary));
@@ -267,26 +281,27 @@ public class CampusMenuActivity extends AppCompatActivity {
                         (int) (8 * scale + 0.5f));
                 mLinLayout.addView(mealItemText);
 
-                // Add divider if text is not the last item in list
-                if (i != menu.size() - 1) {
-                    View divider = new View(this);
-                    divider.setBackgroundColor(
-                            ContextCompat.getColor(getApplicationContext(), R.color.wash));
-                    LinearLayout.LayoutParams dividerParams =
-                            new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT,
-                                    1);
-                    dividerParams.setMargins((int) (15.8 * scale + 0.5f), 0, 0, 0);
-                    divider.setElevation(-1);
-                    divider.setLayoutParams(dividerParams);
-                    mLinLayout.addView(divider);
-                }
+//                // Add divider if text is not the last item in list
+//                if (i != menu.size() - 1) {
+//                    View divider = new View(this);
+//                    divider.setBackgroundColor(
+//                            ContextCompat.getColor(getApplicationContext(), R.color.wash));
+//                    LinearLayout.LayoutParams dividerParams =
+//                            new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT,
+//                                    1);
+//                    dividerParams.setMargins((int) (15.8 * scale + 0.5f), 0, 0, 0);
+//                    divider.setElevation(-1);
+//                    divider.setLayoutParams(dividerParams);
+//                    mLinLayout.addView(divider);
             }
+
         }
         // Formatting for when eatery is a dining hall and has a menu
         else if (mCafeData instanceof DiningHallModel) {
             mMenuText = findViewById(R.id.ind_menu);
             customPager.setVisibility(View.GONE);
             mTabLayout.setVisibility(View.GONE);
+            mExpandedTabLayout.setVisibility(View.GONE);
             ArrayList<MealModel> mm =
                     ((DiningHallModel) mCafeData).getCurrentDayMenu().getAllMeals();
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/MainListFragment.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/MainListFragment.java
@@ -5,8 +5,6 @@ import static com.cornellappdev.android.eatery.model.enums.CampusArea.NORTH;
 import static com.cornellappdev.android.eatery.model.enums.CampusArea.WEST;
 
 import android.Manifest;
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
 import android.content.Intent;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Bundle;

--- a/app/src/main/java/com/cornellappdev/android/eatery/MenuFragment.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/MenuFragment.java
@@ -14,7 +14,6 @@ import com.cornellappdev.android.eatery.model.MealModel;
 
 import java.util.ArrayList;
 
-import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/MenuFragment.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/MenuFragment.java
@@ -14,6 +14,7 @@ import com.cornellappdev.android.eatery.model.MealModel;
 
 import java.util.ArrayList;
 
+import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/model/CafeModel.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/model/CafeModel.java
@@ -1,9 +1,6 @@
 package com.cornellappdev.android.eatery.model;
 
 import android.content.Context;
-import android.os.Parcel;
-import android.os.Parcelable;
-import android.util.Log;
 
 import com.cornellappdev.android.eatery.AllEateriesQuery;
 

--- a/app/src/main/java/com/cornellappdev/android/eatery/model/CafeModel.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/model/CafeModel.java
@@ -21,17 +21,21 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-public class CafeModel extends CampusModel implements Serializable {
+public class CafeModel extends CampusModel implements Serializable  {
     private List<String> mCafeMenu;
-    private HashMap<String, String> mExpandedMenuItems;
-    private HashMap<String, Integer> mExpandedMenuStations;
+    private List<String> mExpandedMenuItems;
+    private List<String> mExpandedMenuPrices;
+    private List<String> mExpandedMenuStations;
+    private List<Integer> mStationSizes;
     private Map<LocalDate, List<Interval>> mHours;
     private List<LocalDate> mSortedDates;
 
     private CafeModel() {
         this.mCafeMenu = new ArrayList<>();
-        this.mExpandedMenuItems = new HashMap<>();
-        this.mExpandedMenuStations = new HashMap<>();
+        this.mExpandedMenuItems = new ArrayList<>();
+        this.mExpandedMenuPrices = new ArrayList<>();
+        this.mExpandedMenuStations = new ArrayList<>();
+        this.mStationSizes = new ArrayList<>();
         this.mHours = new HashMap<>();
         this.mSortedDates = new ArrayList<>();
     }
@@ -42,6 +46,7 @@ public class CafeModel extends CampusModel implements Serializable {
         model.parseEatery(context, hardcoded, cafe);
         return model;
     }
+
 
     private List<Interval> getCurrentIntervalList() {
         LocalDate today = LocalDate.now();
@@ -100,13 +105,17 @@ public class CafeModel extends CampusModel implements Serializable {
         return mCafeMenu;
     }
 
-    public HashMap<String, String> getExpandedMenuItems() {
+    public List<String> getExpandedMenuItems() {
         return mExpandedMenuItems;
     }
 
-    public HashMap<String, Integer> getExpandedMenuStations() {
+    public List<String> getExpandedMenuPrices() { return mExpandedMenuPrices;}
+
+    public List<String> getExpandedMenuStations() {
         return mExpandedMenuStations;
     }
+
+    public List<Integer> getStationSizes() {return mStationSizes;}
 
     @Override
     public Status getCurrentStatus() {
@@ -130,8 +139,10 @@ public class CafeModel extends CampusModel implements Serializable {
     public void parseEatery(Context context, boolean hardcoded, AllEateriesQuery.Eatery cafe) {
         super.parseEatery(context, hardcoded, cafe);
         List<String> cafeItems = new ArrayList<>();
-        HashMap<String, String> expandedMenu = new HashMap();
-        HashMap<String, Integer> expandedStations = new HashMap();
+        List<String> expandedItems = new ArrayList<>();
+        List<String> expandedPrices = new ArrayList<>();
+        List<String> expandedStations = new ArrayList<>();
+        List<Integer> stationSizes = new ArrayList<>();
 
         DateTimeFormatter timeFormatter = new DateTimeFormatterBuilder()
                 .parseCaseInsensitive()
@@ -146,13 +157,15 @@ public class CafeModel extends CampusModel implements Serializable {
             for (AllEateriesQuery.Station station : expanded.stations()) {
                 int stationSize = 0;
                 for (AllEateriesQuery.Item items : station.items()) {
-                    if (!expandedMenu.containsKey(items.item())){
-                        expandedMenu.put(items.item(), items.price());
+                    if (!expandedItems.contains(items.item())){
+                        expandedItems.add(items.item());
+                        expandedPrices.add(items.price());
                         stationSize ++;
                     }
                 }
                 // add station name and size
-                //expandedStations.put(expanded.category(), stationSize);
+                expandedStations.add(expanded.category());
+                stationSizes.add(stationSize);
             }
         }
 
@@ -182,8 +195,11 @@ public class CafeModel extends CampusModel implements Serializable {
                 setHours(localDate, dailyHours);
             }
         }
-        mExpandedMenuItems = expandedMenu;
+        mExpandedMenuItems = expandedItems;
+        mExpandedMenuPrices = expandedPrices;
         mExpandedMenuStations = expandedStations;
+        mStationSizes = stationSizes;
+        mCafeMenu = cafeItems;
     }
 
 }

--- a/app/src/main/java/com/cornellappdev/android/eatery/model/EateryBaseModel.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/model/EateryBaseModel.java
@@ -134,7 +134,6 @@ public abstract class EateryBaseModel implements Serializable, Comparable<Eatery
         mReserveUrl = eatery.reserveUrl();
         mIsGet = eatery.isGet();
         mExceptions = eatery.exceptions();
-        mExpandedMenu = eatery.expandedMenu();
 
         List<PaymentMethod> paymentMethods = new ArrayList<>();
         if (eatery.paymentMethods().brbs()) {

--- a/app/src/main/java/com/cornellappdev/android/eatery/model/EateryBaseModel.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/model/EateryBaseModel.java
@@ -14,6 +14,8 @@ import java.util.List;
 
 import androidx.annotation.NonNull;
 
+import org.jetbrains.annotations.NotNull;
+
 public abstract class EateryBaseModel implements Serializable, Comparable<EateryBaseModel> {
 
     boolean mOpenPastMidnight = false;
@@ -23,6 +25,7 @@ public abstract class EateryBaseModel implements Serializable, Comparable<Eatery
     private String mReserveUrl;
     private ArrayList<String> mSearchedItems;
     private List<String> mExceptions;
+    private @NotNull List<AllEateriesQuery.ExpandedMenu> mExpandedMenu;
     private boolean matchesFilter = true;
     private boolean mMatchesSearch = true;
     private boolean mIsGet = false;
@@ -74,6 +77,8 @@ public abstract class EateryBaseModel implements Serializable, Comparable<Eatery
     public String getReserveUrl() {return mReserveUrl;}
 
     public boolean getIsGet() {return mIsGet;}
+
+    public List<AllEateriesQuery.ExpandedMenu> getExpandedMenu() {return mExpandedMenu;}
 
     public void setSearchedItems(ArrayList<String> searchedItems) {
         this.mSearchedItems = searchedItems;
@@ -129,6 +134,7 @@ public abstract class EateryBaseModel implements Serializable, Comparable<Eatery
         mReserveUrl = eatery.reserveUrl();
         mIsGet = eatery.isGet();
         mExceptions = eatery.exceptions();
+        mExpandedMenu = eatery.expandedMenu();
 
         List<PaymentMethod> paymentMethods = new ArrayList<>();
         if (eatery.paymentMethods().brbs()) {

--- a/app/src/main/java/com/cornellappdev/android/eatery/model/MealMenuModel.java
+++ b/app/src/main/java/com/cornellappdev/android/eatery/model/MealMenuModel.java
@@ -20,7 +20,7 @@ public class MealMenuModel implements Serializable {
     static MealMenuModel fromGraphQL(List<AllEateriesQuery.Menu> menuList) {
         MealMenuModel menuModel = new MealMenuModel();
         for (AllEateriesQuery.Menu menu : menuList) {
-            for (AllEateriesQuery.Item item : menu.items()) {
+            for (AllEateriesQuery.Item1 item : menu.items()) {
                 menuModel.addItem(menu.category(), item.item());
             }
         }

--- a/app/src/main/res/drawable/button.xml
+++ b/app/src/main/res/drawable/button.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <corners
-        android:radius="2dp"
+        android:radius="8dp"
         />
     <solid
         android:color="@color/wash"/>

--- a/app/src/main/res/layout/activity_campus_eatery.xml
+++ b/app/src/main/res/layout/activity_campus_eatery.xml
@@ -216,6 +216,16 @@
                 android:orientation="vertical"/>
 
             <com.google.android.material.tabs.TabLayout
+                android:id="@+id/expandedTabs"
+                android:layout_width="wrap_content"
+                app:tabMode="scrollable"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:background="@color/white"
+                app:tabIndicatorColor="@color/blue"
+                app:tabTextAppearance="@style/tabLayoutText"/>
+
+            <com.google.android.material.tabs.TabLayout
                 android:id="@+id/tabs"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_campus_eatery.xml
+++ b/app/src/main/res/layout/activity_campus_eatery.xml
@@ -13,7 +13,8 @@
         android:id="@+id/appbar"
         android:layout_width="match_parent"
         android:background="@color/white"
-        android:layout_height="275dp">
+        android:layout_height="wrap_content">
+
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
             android:id="@+id/collapsing_toolbar"
@@ -121,6 +122,7 @@
                 android:minHeight="?attr/actionBarSize"
                 app:layout_collapseMode="pin"/>
         </com.google.android.material.appbar.CollapsingToolbarLayout>
+
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.core.widget.NestedScrollView
@@ -132,6 +134,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:id="@+id/master_container"
             android:background="@color/wash"
             android:orientation="vertical">
 
@@ -143,8 +146,6 @@
                 android:elevation="1dp"
                 android:paddingTop="12dp"
                 android:paddingBottom="12dp">
-
-
 
                 <TextView
                     android:id="@+id/ind_open"
@@ -206,7 +207,22 @@
                 android:paddingBottom="12dp"
                 android:text="@string/eatery_menu_label"
                 android:textColor="@color/primary"
-                android:textSize="16sp"/>
+                android:textStyle="bold"
+                android:textSize="24sp"/>
+
+            <com.google.android.material.tabs.TabLayout
+                android:id="@+id/expandedTabs"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:minHeight="?attr/actionBarSize"
+                app:tabGravity="fill"
+                android:paddingStart="6dp"
+                app:tabBackground="@color/white"
+                app:tabIndicatorColor="@color/blue"
+                app:tabIndicatorFullWidth="false"
+                app:tabIndicatorHeight="4dp"
+                app:tabMode="scrollable"/>
 
             <LinearLayout
                 android:id="@+id/linear"
@@ -214,16 +230,6 @@
                 android:layout_height="wrap_content"
                 android:background="@color/white"
                 android:orientation="vertical"/>
-
-            <com.google.android.material.tabs.TabLayout
-                android:id="@+id/expandedTabs"
-                android:layout_width="wrap_content"
-                app:tabMode="scrollable"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="12dp"
-                android:background="@color/white"
-                app:tabIndicatorColor="@color/blue"
-                app:tabTextAppearance="@style/tabLayoutText"/>
 
             <com.google.android.material.tabs.TabLayout
                 android:id="@+id/tabs"

--- a/app/src/main/res/layout/card_item.xml
+++ b/app/src/main/res/layout/card_item.xml
@@ -13,7 +13,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:cardBackgroundColor="@color/white"
-        app:cardCornerRadius="2dp"
+        app:cardCornerRadius="10dp"
         app:cardElevation="4dp"
         app:cardPreventCornerOverlap="true"
         app:cardUseCompatPadding="true">

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.google.gms:google-services:4.2.0'
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.apollographql.apollo:apollo-gradle-plugin:1.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.google.gms:google-services:4.2.0'
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath 'com.apollographql.apollo:apollo-gradle-plugin:1.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
## Overview

* Added expanded menus feature
* New backend queries and parsing from graphql
* Updated base model
* Change some cross activity intent code
* Design changes



## Changes Made

* Eatery base model now parses expanded items, expanded prices, expanded sections, and expanded sizes all from backend query of graphql
* Appropriate getters made
* New tab layout made for each section of expanded menu
* New layout inflator which has cells of item text on left and price on right and are alligned 
* Made some serializable vs parseable changes in intent bundle extras when sending across activities
* Changed the UI to match most recent designs


## Test Coverage
* Tested on Oneplus 7 Pro


## Next Steps 
* Make tab layout pin to the top of the screen when scrolling (legacy app bar code prevents the use of a CoordinaterLayout)
* Use a more precise way to programmatically scroll to item in the LinearLayout (requestChildFocus() is approximate)


## Screenshots 

<details>

  <summary>Main</summary>


![Screenshot_20210503_045128](https://user-images.githubusercontent.com/58797934/116857934-99160500-abcb-11eb-9ede-3623c5142ce6.png)

  

</details>

<details>

  <summary>Details</summary>

![Screenshot_20210503_045244](https://user-images.githubusercontent.com/58797934/116857919-93202400-abcb-11eb-8ad4-c4801e174a1f.png)



</details>
